### PR TITLE
Update link to Port a Google Chrome Extension

### DIFF
--- a/_includes/home/build.md
+++ b/_includes/home/build.md
@@ -107,7 +107,7 @@ Already have an extension that works in Chrome? Bring your app to Firefox in a f
 
 Top Resources  
 [Differences between Chrome and Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities)
-[Port a Google Chrome extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Porting)
+[Port a Google Chrome extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Porting_a_Google_Chrome_extension)
 
 </div>
 


### PR DESCRIPTION
Changed link target to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Porting_a_Google_Chrome_extension.

For #17 . 