### PR TITLE
Update link to Introduction to developing in Firefox

### DIFF
--- a/_includes/home/build.md
+++ b/_includes/home/build.md
@@ -130,7 +130,7 @@ Starting from scratch? It’s easy and fast to create your cross-browser extensi
 
 Top Resources  
 [Best practices for cross-browser extensions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension)
-[Introduction to developing in Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Temporary_Installation_in_Firefox)
+[Introduction to developing in Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Firefox_workflow_overview)
 
 </div>
 


### PR DESCRIPTION
For issue #24.

Changes link for "Introduction to Developing in Firefox" to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Firefox_workflow_overview