### PR TITLE
Update footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,7 +9,7 @@
           <a href="https://addons.mozilla.org/">Add-ons</a>
         </h4>
         <ul>
-          <li><a href="https://https://addons.mozilla.org/en-US/about">About</a></li>
+          <li><a href="https://addons.mozilla.org/en-US/about">About</a></li>
           <li><a href="https://blog.mozilla.com/addons">Blog</a></li>
           <li><a href="https://addons.mozilla.org/developers/">Developer Hub</a></li>
 	  <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/AMO/Policy">Developer Policies"</a></li>


### PR DESCRIPTION
For issue #26. Removes links to Mozilla and replaces them with links to addons.mozilla.org, add-ons blog, add-ons Dev Hub, Dev Policies, and forum.