### PR TITLE
Add the data-no-csrf attribute to forms

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -52,7 +52,7 @@
       </div>
 
       <div class="cell small-12 large-4">
-	      <form class="mzp-c-language-switcher mzp-t-dark" method="get" action="#">
+	      <form class="mzp-c-language-switcher mzp-t-dark" method="get" action="#" data-no-csrf>
 	        <a class="mzp-c-cta-link" href="https://www.mozilla.org/locales/">Language</a>
 	        <label for="mzp-c-language-switcher-select">Language</label>
 	        <select id="mzp-c-language-switcher-select" class="mzp-js-language-switcher-select"

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -90,7 +90,7 @@ layout: landing
                 <p>Stay up-to-date on news and events for Firefox extension developers.</p>
 
                 <div class="newsletter" id="newsletter_wrap">
-                    <form id="newsletter_form" name="newsletter_form" action="https://www.mozilla.org/en-US/newsletter/" method="post">
+                    <form id="newsletter_form" name="newsletter_form" action="https://www.mozilla.org/en-US/newsletter/" method="post" data-no-csrf>
                         <input type="hidden" id="fmt" name="fmt" value="H">
                         <input type="hidden" id="newsletters" name="newsletters" value="about-addons">
 


### PR DESCRIPTION
This attribute is used to indicate to the ZAP baseline scan that the forms in question do not need anti CSRF tokens.