### PR TITLE
Relax frame-src to allow youtube embeds

### DIFF
--- a/.utils/deploy.sh
+++ b/.utils/deploy.sh
@@ -38,7 +38,7 @@ CSP="\"content-security-policy\": \"default-src 'none'; "\
 "font-src 'self'; "\
 "form-action https://www.mozilla.org/en-US/newsletter/; "\
 "frame-ancestors 'none'; "\
-"frame-src https://www.youtube.com/embed/Q3AQ5D2QFwc; "\
+"frame-src https://www.youtube.com/embed/; "\
 "img-src 'self' data:; "\
 "object-src 'none'; "\
 "script-src 'self' https://www.youtube.com/iframe_api https://s.ytimg.com/yts/jsbin/; "\


### PR DESCRIPTION
Fixes #73 

This will allow any youtube embed which is more practical than having to update the CSP every time a new video is linked to.