### PR TITLE
Add draft feature to content-guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ This site has two templates: the Extension Workshop landing page and Content Gui
 
 1. Create new file
 2. Add header (see example below)
-3. Copy 'modules' needed from content-guidelines-master-template.md and paste in new file
-4. Save as markdown: page-name.md
+3. Copy 'modules' needed from `content-guidelines/master-template.md` and paste in new file
+4. Save as markdown: `content-guidelines/page-name.md`
 
 ```
 ---
@@ -66,13 +66,17 @@ For finer control you can use:
 
 #### Add the page to the menu
 
-Go to data/content-guidelines-pages.yaml and add a new entry for your page:
+Go to `_data/content-guidelines-pages.yaml` and add a new entry for your page:
 
 ```
 - title: "Page Name"
   url: "/content-guidelines/page-name/"
-
+  draft: true
 ```
+
+#### Controlling draft state
+
+If you don't want the page to appear as a draft or as and when it's ready remove `draft: true` from the relevant entry in `_data/content-guidelines.yaml`
 
 ## Deployment
 

--- a/_assets/css/_contentguidelines.scss
+++ b/_assets/css/_contentguidelines.scss
@@ -1,8 +1,46 @@
 /************************************************
 
-Stylesheet: Conteng Guidelines Stylesheet
+Stylesheet: Content Guidelines Stylesheet
 
 *************************************************/
+
+// Style for "DRAFT" items in the sidebar nav
+.draft {
+  background-color: #ffe900;
+  padding: 4px;
+  font-weight: bold;
+  font-size: 0.8em;
+  border-radius: 2px;
+  text-transform: uppercase;
+  margin: 0 5px;
+}
+
+// Style for warnings
+.warning {
+  display: inline;
+  background-color: #ffe900;
+  border-radius: 2px;
+  padding: 10px 6px;
+  line-height: 1.5;
+
+  img {
+    margin-top: -1px;
+    vertical-align: middle;
+  }
+
+  a {
+    background: #d7b600;
+    border-radius: 2px;
+    color: #0c0c0d;
+    padding: 6px 4px;
+
+    &:hover,
+    &:active,
+    &:visited {
+      color: #0c0c0d;
+    }
+  }
+}
 
 $sidebar-w-sm: rem-calc(200);
 $sidebar-w: rem-calc(230);

--- a/_assets/img/icons/warning.svg
+++ b/_assets/img/icons/warning.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="rgba(12, 12, 13, .8)" d="M14.742 12.106L9.789 2.2a2 2 0 0 0-3.578 0l-4.953 9.91A2 2 0 0 0 3.047 15h9.905a2 2 0 0 0 1.79-2.894zM7 5a1 1 0 0 1 2 0v4a1 1 0 0 1-2 0zm1 8.25A1.25 1.25 0 1 1 9.25 12 1.25 1.25 0 0 1 8 13.25z"/>
+</svg>

--- a/_data/content-guidelines-pages.yaml
+++ b/_data/content-guidelines-pages.yaml
@@ -1,8 +1,11 @@
 - title: "Master Template"
   url: "/content-guidelines/master-template/"
+  draft: true
 
 - title: "Extension Name"
   url: "/content-guidelines/extension-name/"
+  draft: true
 
 - title: "Example Two"
   url: "/content-guidelines/example-two/"
+  draft: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,15 @@
 	            	<ul class="pages">
 					    {% for item in site.data.content-guidelines-pages %}
 						    {% if page.url == item.url %}
-					            <li class="current"><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
+							<li class="current">
+								<a href="{{ item.url | relative_url }}">{{ item.title }}</a>
+								{% if item.draft %}<span class="draft">draft</span>{% endif %}
+							</li>
 					        {% else %}
-					      		<li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
+							<li>
+								<a href="{{ item.url | relative_url }}">{{ item.title }}</a>
+								{% if item.draft %}<span class="draft">draft</span>{% endif %}
+							</li>
 					        {% endif %}
 					    {% endfor %}
 					    <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Listing" target="_blank" rel="noreferrer noopener">More Tips</a></li>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,7 +8,7 @@ layout: default
 		    <div class="post-content">
 			    {% for item in site.data.content-guidelines-pages %}
 					{% if item.url == page.url and item.draft %}
-					<p class="warning">{% asset icons/warning.svg @optim alt="Warning:" %} This is a working draft <a href="https://github.com/mozilla/extension-workshop/issues/new">Report issue</a></p>
+					<p class="warning">{% asset icons/warning.svg @optim alt="Warning:" %} This is a working draft</p>
 			        {% endif %}
 			    {% endfor %}
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,9 +6,14 @@ layout: default
         <div class="cell small-12">
 
 		    <div class="post-content">
+			    {% for item in site.data.content-guidelines-pages %}
+					{% if item.url == page.url and item.draft %}
+					<p class="warning">{% asset icons/warning.svg @optim alt="Warning:" %} This is a working draft <a href="https://github.com/mozilla/extension-workshop/issues/new">Report issue</a></p>
+			        {% endif %}
+			    {% endfor %}
+
 		    	{{ content }}
 		    </div>
-		    
 		</div>
 	</div>
 </article>


### PR DESCRIPTION
Fixes #78 

Looks like this (click on the image to view it larger):

![master_template___extension_workshop](https://user-images.githubusercontent.com/1514/52478341-feb9e900-2b9c-11e9-99d0-eb140ec4eba2.jpg)

You can turn it on and off per-page by `editing _data/content-guidelines-pages.yaml` 

If the entry has `draft: true` it will show the draft messaging if not, it won't.

![nvim](https://user-images.githubusercontent.com/1514/52478385-2315c580-2b9d-11e9-9e2c-f1cfa16531ae.jpg)

In the patch draft is enabled for all the content-guidelines (the example have it switched off for one page just to prove it's conditional).

It might be nice to remove the "Example two" page since that mostly is linking to resources about Jekyll rather than anything to do with content guidelines. See https://extensionworkshop.allizom.org/content-guidelines/example-two/