### PR TITLE
Update sidebar links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,11 +26,10 @@
 					    <li><a href="https://developer.mozilla.org/docs/Mozilla/Add-ons/Listing" target="_blank" rel="noreferrer noopener">More Tips</a></li>
 					</ul>
 
-					<p><a href="https://addons.mozilla.org/developers/" class="button" target="_blank" rel="noreferrer noopener">Edit Product Page</a></p>
+					<p><a href="https://addons.mozilla.org/developers/addons" class="button" target="_blank" rel="noreferrer noopener">Edit Product Page</a></p>
 					<p><a href="{{ "/" | relative_url }}" class="back">Extension Workshop</a></p>
-					<p class="site-metadata"><a href="">Site Feedback</a>
-						<br><a href="">Changelog</a> v0.6.8
-						<br><a href="">Privacy Policy</a>
+					<p class="site-metadata"><a href="https://github.com/mozilla/extension-workshop/issues/new">Site Feedback</a>
+						<br><a href="https://www.mozilla.org/privacy/websites/">Privacy Policy</a>
 					</p>
 				</nav>
             </div>


### PR DESCRIPTION
Fixes #80

_Note the "Site Feedback" link goes to https://github.com/mozilla/extension-workshop/issues/new_