### PR TITLE
Added Extension Title and Extension Subtitle to .yaml

### DIFF
--- a/_data/content-guidelines-pages.yaml
+++ b/_data/content-guidelines-pages.yaml
@@ -10,6 +10,6 @@
   url: "/content-guidelines/extension-title/"
   draft: true
   
-  - title: "Extension Subtitle"
+ - title: "Extension Subtitle"
   url: "/content-guidelines/extension-subtitle/"
   draft: true

--- a/_data/content-guidelines-pages.yaml
+++ b/_data/content-guidelines-pages.yaml
@@ -10,6 +10,6 @@
   url: "/content-guidelines/extension-title/"
   draft: true
   
- - title: "Extension Subtitle"
+- title: "Extension Subtitle"
   url: "/content-guidelines/extension-subtitle/"
   draft: true

--- a/_data/content-guidelines-pages.yaml
+++ b/_data/content-guidelines-pages.yaml
@@ -6,3 +6,10 @@
   url: "/content-guidelines/extension-name/"
   draft: true
 
+- title: "Extension Title"
+  url: "/content-guidelines/extension-title/"
+  draft: true
+  
+  - title: "Extension Subtitle"
+  url: "/content-guidelines/extension-subtitle/"
+  draft: true


### PR DESCRIPTION
Added Extension Title & Extension Subtitle pages (draft = true) to _data/content-guidelines-pages.yaml to update sidebar for content guidelines.