### PR TITLE
Enable pushing to -prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,5 +88,4 @@ workflows:
             branches:
               only: master
             tags:
-              # only: /^v?[0-9]+(\.[0-9]+)*$/
-              ignore: /.*/
+              only: /^v?[0-9]+(\.[0-9]+)*$/


### PR DESCRIPTION
With this change, tagging a release will trigger pushing to -prod.