### PR TITLE
Fix draft label wrapping

### DIFF
--- a/_assets/css/_contentguidelines.scss
+++ b/_assets/css/_contentguidelines.scss
@@ -7,12 +7,11 @@ Stylesheet: Content Guidelines Stylesheet
 // Style for "DRAFT" items in the sidebar nav
 .draft {
   background-color: #ffe900;
-  padding: 4px;
+  padding: 4px 3px;
   font-weight: bold;
-  font-size: 0.8em;
+  font-size: 0.7em;
   border-radius: 2px;
   text-transform: uppercase;
-  margin: 0 5px;
 }
 
 // Style for warnings


### PR DESCRIPTION
Fixes #96

Tweak draft label styling to prevent wrapping.

Before:

![master_template___extension_workshop](https://user-images.githubusercontent.com/1514/52785453-ec81f400-304f-11e9-82e2-37fcc11435e1.jpg)

After:

![master_template___extension_workshop](https://user-images.githubusercontent.com/1514/52785592-41be0580-3050-11e9-942a-3ebc6c6b07c7.jpg)
