### PR TITLE
Fix local build speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Note: Running locally will show unpublished content that uses the `published: fa
 
 | Command             | Description                                                                             |
 | ------------------- | --------------------------------------------------------------------------------------- |
-| yarn start          | Starts jekyll and includes unpublished content.                                         |
+| yarn clean          | Clears the output directly and cleans the .jekyll-cache.                                |
+| yarn build          | Builds the site.                                                                        |
+| yarn start          | Starts jekyll and includes unpublished content. (Note the first run is slow!)           |
 | yarn start-prodlike | Starts jekyll and doesn't include unpublished content for a production-like experience. |
 
 ## Content Updates

--- a/_config.yml
+++ b/_config.yml
@@ -55,10 +55,6 @@ exclude:
 
 assets:
   compression: true
-  caching:
-    path: ".jekyll-cache/assets"
-    type: memory
-    enabled: true
   sources:
     - _assets/img
     - _assets/css

--- a/_config_local.yml
+++ b/_config_local.yml
@@ -1,0 +1,13 @@
+assets:
+  compression: false
+  caching:
+    path: ".jekyll-cache/assets"
+    type: file
+    enabled: true
+  defaults:
+    js:
+      integrity: false
+    css:
+      integrity: false
+    img:
+      integrity: false

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-prettier": "3.0.1",
     "prettier": "1.16.4",
     "pretty-quick": "1.10.0",
+    "rimraf": "^2.6.3",
     "svgo": "1.1.1"
   },
   "scripts": {
@@ -29,7 +30,9 @@
     "prettier-ci": "prettier -c '**'",
     "prettier-dev": "pretty-quick --branch master",
     "test": "npm run prettier-ci && npm run lint",
-    "start": "SVGO_BIN='node_modules/svgo/bin/svgo' jekyll serve --unpublished",
+    "clean": "rimraf './.jekyll-cache/' && jekyll clean",
+    "build": "JEKYLL_ENV=production SVGO_BIN='node_modules/svgo/bin/svgo' jekyll build",
+    "start": "jekyll serve --unpublished --config _config.yml,_config_local.yml",
     "start-prodlike": "SVGO_BIN='node_modules/svgo/bin/svgo' jekyll serve"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,7 +1006,7 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-rimraf@2.6.3:
+rimraf@2.6.3, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==


### PR DESCRIPTION
Fixes #72

The first build is ~45s and then follow-up builds are under 1s.

Unfortunately there's an issue that if you simply run `jekyll clean` leaving `.jekyll-cache` in place the files referenced in the CSS are not copied the next time you run `jekyll serve`. To work around this `yarn clean` has been added which additionally purges the asset cache which solves this problem.

