### PR TITLE
Removed the Section H2 header in Enterprise page

### DIFF
--- a/_data/pages.yaml
+++ b/_data/pages.yaml
@@ -550,8 +550,6 @@
     - title: "Enterprise"
       url: "/documentation/enterprise/"
       subpageitems:
-        - title: "Section Title"
-          id: "introduction"
         - title: "Developing your enterprise extension"
           id: "developing-your-enterprise-extension"
         - title: "Distributing your enterprise extension"


### PR DESCRIPTION
Squashes #232 

This PR removes the `section title` H2 header on Enterprise page through `_data/pages.yml` file. 

Cc: @caitmuenster @championshuttler 