### PR TITLE
Updated links on Firefox workflow overview

### DIFF
--- a/documentation/develop/firefox-workflow-overview.md
+++ b/documentation/develop/firefox-workflow-overview.md
@@ -52,7 +52,7 @@ date: 2019-05-20 03:25:40
         <td>Choose your IDE or code editor</td>
         <td>Run your extension with <a href="/documentation/develop/getting-started-with-web-ext#testing-out-an-extension">web-ext run</a> or <a href="/documentation/develop/temporary-installation-in-firefox/">about:debugging</a></td>
         <td>Create an <a href="https://addons.mozilla.org">addons.mozilla.org</a>account</td>
-      <td><a href="/documentation/publish/promoting-your-extension/"Promote your extension</a></td>
+      <td><a href="/documentation/publish/promoting-your-extension/">Promote your extension</a></td>
         <td></td>
     </tr>
     <tr>

--- a/documentation/develop/firefox-workflow-overview.md
+++ b/documentation/develop/firefox-workflow-overview.md
@@ -43,7 +43,7 @@ date: 2019-05-20 03:25:40
     </tr>
     <tr>
         <td><a href="/documentation/develop/choosing-a-firefox-version-for-extension-development">Choose a Firefox version for web extension development</a></td>
-        <td><a href="/documentation/develop/your-first-extension/">Code your extension</a></td>
+        <td>Code your extension</td>
         <td> Package your extension with <a href="/documentation/develop/getting-started-with-web-ext#packaging-your-extension">web-ext build</a></td>
         <td> Responded to Mozilla extension review</td>
         <td><a href="/documentation/manage/retiring-your-extension">Retire your extension</a></td>
@@ -52,7 +52,7 @@ date: 2019-05-20 03:25:40
         <td>Choose your IDE or code editor</td>
         <td>Run your extension with <a href="/documentation/develop/getting-started-with-web-ext#testing-out-an-extension">web-ext run</a> or <a href="/documentation/develop/temporary-installation-in-firefox/">about:debugging</a></td>
         <td>Create an <a href="https://addons.mozilla.org">addons.mozilla.org</a>account</td>
-        <td><a href="/documentation/publish/promoting-your-extension/"</a>Promote your extension</td>
+      <td><a href="/documentation/publish/promoting-your-extension/"Promote your extension</a></td>
         <td></td>
     </tr>
     <tr>

--- a/documentation/develop/firefox-workflow-overview.md
+++ b/documentation/develop/firefox-workflow-overview.md
@@ -59,7 +59,7 @@ date: 2019-05-20 03:25:40
         <td><a href="/documentation/develop/getting-started-with-web-ext/">Install web-ext</a></td>
         <td><a href="/documentation/develop/testing-persistent-and-restart-features/">Test persistent and restart features</a></td>
         <td><a href="/documentation/publish/submitting-an-add-on">Submit your extension</a></td>
-        <td>Nominate your extension to be recommended</td>
+        <td><a href="https://blog.mozilla.org/addons/2019/04/08/recommended-extensions-program-coming-soon/">Nominate your extension to be recommended</a></td>
         <td></td>
     </tr>
     <tr>

--- a/documentation/develop/firefox-workflow-overview.md
+++ b/documentation/develop/firefox-workflow-overview.md
@@ -52,7 +52,7 @@ date: 2019-05-20 03:25:40
         <td>Choose your IDE or code editor</td>
         <td>Run your extension with <a href="/documentation/develop/getting-started-with-web-ext#testing-out-an-extension">web-ext run</a> or <a href="/documentation/develop/temporary-installation-in-firefox/">about:debugging</a></td>
         <td>Create an <a href="https://addons.mozilla.org">addons.mozilla.org</a>account</td>
-        <td>Promote your extension</td>
+        <td><a href="/documentation/publish/promoting-your-extension/"</a>Promote your extension</td>
         <td></td>
     </tr>
     <tr>
@@ -65,20 +65,20 @@ date: 2019-05-20 03:25:40
     <tr>
         <td><a href="http://webextensions.tech/">Create your extension scaffold</a></td>
         <td>Debug with the <a href="https://developer.mozilla.org/en-US/docs/Tools/Browser_Toolbox/">Add-on Debugging Window</a></td>
-        <td><a href="/documentation/publish/source-code-submission">Submit your source code</a> (if required)</td>
-        <td>Update and improve your extension</td>
+        <td><a href="/documentation/publish/source-code-submission/">Submit your source code</a> (if required)</td>
+        <td><a href="/documentation/manage/updating-your-extension/">Update and improve your extension</a></td>
         <td></td>
     </tr>
     <tr>
-        <td>Get familiar with the <a href="/documentation/publish/add-on-policies/">add-on policies</a> and <a href="/documentation/publish/firefox-add-on-distribution-agreement">developer agreement</a></td>
+        <td>Get familiar with the <a href="/documentation/publish/add-on-policies/">add-on policies</a> and <a href="/documentation/publish/firefox-add-on-distribution-agreement/">developer agreement</a></td>
         <td></td>
-        <td><a href="/documentation/develop/create-an-appealing-listing">Create an appealing listing</a></td>
+        <td><a href="/documentation/develop/create-an-appealing-listing/">Create an appealing listing</a></td>
         <td></td>
         <td></td>
     </tr>
 </table>
 
-<p>* Or distribute your extension for <a href="/documentation/publish/sideloading-add-ons/">sideloading</a>, <a href="/documentation/publish/add-ons-for-desktop-apps/">desktop apps</a>, or <a href="/documentation/enterprise/add-ons-in-the-enterprise/">in an enterprise</a>.</p>
+<p>* Or distribute your extension for <a href="/documentation/publish/distribute-sideloading/">sideloading</a>, <a href="/documentation/publish/distribute-for-desktop-apps/">desktop apps</a>, or <a href="/documentation/enterprise/enterprise-distribution/">in an enterprise</a>.</p>
 
 **Have an extension you want to bring to Firefox?** We provide advice, guidelines, and tools to help making make porting straightforward. To get started, visit [Porting a Google Chrome extension](/documentation/develop/porting-a-google-chrome-extension/).
 

--- a/documentation/develop/firefox-workflow-overview.md
+++ b/documentation/develop/firefox-workflow-overview.md
@@ -51,7 +51,7 @@ date: 2019-05-20 03:25:40
     <tr>
         <td>Choose your IDE or code editor</td>
         <td>Run your extension with <a href="/documentation/develop/getting-started-with-web-ext#testing-out-an-extension">web-ext run</a> or <a href="/documentation/develop/temporary-installation-in-firefox/">about:debugging</a></td>
-        <td>Create an <a href="https://addons.mozilla.org">addons.mozilla.org</a>account</td>
+        <td>Create an <a href="https://addons.mozilla.org">addons.mozilla.org</a> account</td>
       <td><a href="/documentation/publish/promoting-your-extension/">Promote your extension</a></td>
         <td></td>
     </tr>


### PR DESCRIPTION
This fixes #350 in the file `firefox-workflow-overview.md`

Fixes the 404 links to : 
- Sideloading add-ons 
- Desktop apps 
- Enterprise 

Added the links to: 
-  Promote your extension
-  Update your extension

CC: @caitmuenster
Also, I couldn't find an appropriate link for `Featured extensions`, let me know how to fix it! 
