### PR TITLE
Updated footer links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
           <li><a href="https://addons.mozilla.org/about">About</a></li>
           <li><a href="https://blog.mozilla.com/addons">Blog</a></li>
           <li><a href="https://addons.mozilla.org/developers/">Developer Hub</a></li>
-          <li><a href="https://developer.mozilla.org/docs/Mozilla/Add-ons/AMO/Policy">Developer Policies</a></li>
+          <li><a href="/documentation/publish/add-on-policies/">Developer Policies</a></li>
           <li><a href="https://discourse.mozilla.org/c/add-ons">Forum</a></li>
         </ul>
       </section>


### PR DESCRIPTION
Fixes #381 

In the `footer.html` file, the link to the Developer Policies was changed to `/documentation/publish/add-on-policies/`.

cc: @championshuttler @caitmuenster 
