### PR TITLE
Fire media changes when matches are false as well as true

### DIFF
--- a/_assets/js/breakpoints.js
+++ b/_assets/js/breakpoints.js
@@ -14,6 +14,7 @@
  * Changelog:
  * v 1.0 20.09.2013
  * v 2.0 28.02.2014 -- added configurable breakpoints
+ * v 2.1 25.09.2019 -- fixed breakpoints to publish if matches is defined.
  *
  * --------------------------------------------------------------------
  */
@@ -55,7 +56,7 @@
     // media query change
     // ------------------
     function breakpoint(mq) {
-      if (mq.matches) {
+      if (typeof mq.matches !== 'undefined') {
         var media = {};
         for (var i = 0; i < matches.length; i++) {
           media[matches[i].label] = matches[i].match.matches;


### PR DESCRIPTION
Fixes #433

The breakpoint events were only published when matches for a subscribed media query were true. This change makes it fire when matches is not undefined instead so it will fire for both true and false. 

The way the breakpoints code is written this means it will fire more often because it fires for every media query defined in breakpoints.js, however, the subscribed events seem to be no-op if the change doesn't need to be made, so this shouldn't cause a problem.

At some point in the breakpoints code could be refactored further.