### PR TITLE
Fix table style and markup

### DIFF
--- a/documentation/develop/firefox-workflow-overview.md
+++ b/documentation/develop/firefox-workflow-overview.md
@@ -34,48 +34,52 @@ date: 2019-05-20 03:25:40
 {% capture content %}
 
 <table>
-    <tr align="left" style="font-size: 24px">
-        <th>Prepare</th>
-        <th>Code</th>
-        <th>Publish<a href="#distribute-extension">*</a></th>
-        <th>Enhance</th>
-        <th>Retire</th>
-    </tr>
-    <tr style="font-size: 14px">
-        <td><a href="/documentation/develop/choosing-a-firefox-version-for-extension-development">Choose a Firefox version for web extension development</a></td>
-        <td>Code your extension</td>
-        <td> Package your extension with <a href="/documentation/develop/getting-started-with-web-ext#packaging-your-extension">web-ext build</a></td>
-        <td> Responded to Mozilla extension review</td>
-        <td><a href="/documentation/manage/retiring-your-extension">Retire your extension</a></td>
-    </tr>
-    <tr style="font-size: 14px">
-        <td>Choose your IDE or code editor</td>
-        <td>Run your extension with <a href="/documentation/develop/getting-started-with-web-ext#testing-out-an-extension">web-ext run</a> or <a href="/documentation/develop/temporary-installation-in-firefox/">about:debugging</a></td>
-        <td>Create an <a href="https://addons.mozilla.org">addons.mozilla.org</a> account</td>
-      <td><a href="/documentation/publish/promoting-your-extension/">Promote your extension</a></td>
-        <td></td>
-    </tr>
-    <tr style="font-size: 14px">
-        <td><a href="/documentation/develop/getting-started-with-web-ext/">Install web-ext</a></td>
-        <td><a href="/documentation/develop/testing-persistent-and-restart-features/">Test persistent and restart features</a></td>
-        <td><a href="/documentation/publish/submitting-an-add-on">Submit your extension</a></td>
-        <td><a href="https://blog.mozilla.org/addons/2019/04/08/recommended-extensions-program-coming-soon/">Nominate your extension to be recommended</a></td>
-        <td></td>
-    </tr>
-    <tr style="font-size: 14px">
-        <td><a href="http://webextensions.tech/">Create your extension scaffold</a></td>
-        <td>Debug with the <a href="https://developer.mozilla.org/docs/Tools/Browser_Toolbox/">Add-on Debugging Window</a></td>
-        <td><a href="/documentation/publish/source-code-submission/">Submit your source code</a> (if required)</td>
-        <td><a href="/documentation/manage/updating-your-extension/">Update and improve your extension</a></td>
-        <td></td>
-    </tr>
-    <tr style="font-size: 14px">
-        <td>Get familiar with the <a href="/documentation/publish/add-on-policies/">add-on policies</a> and <a href="/documentation/publish/firefox-add-on-distribution-agreement/">developer agreement</a></td>
-        <td></td>
-        <td><a href="/documentation/develop/create-an-appealing-listing/">Create an appealing listing</a></td>
-        <td></td>
-        <td></td>
-    </tr>
+    <thead>
+        <tr>
+            <th>Prepare</th>
+            <th>Code</th>
+            <th>Publish<a href="#distribute-extension">*</a></th>
+            <th>Enhance</th>
+            <th>Retire</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><a href="/documentation/develop/choosing-a-firefox-version-for-extension-development">Choose a Firefox version for web extension development</a></td>
+            <td>Code your extension</td>
+            <td> Package your extension with <a href="/documentation/develop/getting-started-with-web-ext#packaging-your-extension">web-ext build</a></td>
+            <td> Responded to Mozilla extension review</td>
+            <td><a href="/documentation/manage/retiring-your-extension">Retire your extension</a></td>
+        </tr>
+        <tr>
+            <td>Choose your IDE or code editor</td>
+            <td>Run your extension with <a href="/documentation/develop/getting-started-with-web-ext#testing-out-an-extension">web-ext run</a> or <a href="/documentation/develop/temporary-installation-in-firefox/">about:debugging</a></td>
+            <td>Create an <a href="https://addons.mozilla.org">addons.mozilla.org</a> account</td>
+          <td><a href="/documentation/publish/promoting-your-extension/">Promote your extension</a></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><a href="/documentation/develop/getting-started-with-web-ext/">Install web-ext</a></td>
+            <td><a href="/documentation/develop/testing-persistent-and-restart-features/">Test persistent and restart features</a></td>
+            <td><a href="/documentation/publish/submitting-an-add-on">Submit your extension</a></td>
+            <td><a href="https://blog.mozilla.org/addons/2019/04/08/recommended-extensions-program-coming-soon/">Nominate your extension to be recommended</a></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><a href="http://webextensions.tech/">Create your extension scaffold</a></td>
+            <td>Debug with the <a href="https://developer.mozilla.org/docs/Tools/Browser_Toolbox/">Add-on Debugging Window</a></td>
+            <td><a href="/documentation/publish/source-code-submission/">Submit your source code</a> (if required)</td>
+            <td><a href="/documentation/manage/updating-your-extension/">Update and improve your extension</a></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Get familiar with the <a href="/documentation/publish/add-on-policies/">add-on policies</a> and <a href="/documentation/publish/firefox-add-on-distribution-agreement/">developer agreement</a></td>
+            <td></td>
+            <td><a href="/documentation/develop/create-an-appealing-listing/">Create an appealing listing</a></td>
+            <td></td>
+            <td></td>
+        </tr>
+    </tbody>
 </table>
 
 <p id="distribute-extension">* Or distribute your extension for <a href="/documentation/publish/distribute-sideloading/">sideloading</a>, <a href="/documentation/publish/distribute-for-desktop-apps/">desktop apps</a>, or <a href="/documentation/enterprise/enterprise-distribution/">in an enterprise</a>.</p>


### PR DESCRIPTION
Fixes #464
Fixes #448

* Removes inline styles.
* Adds `thead` and `tbody`.

Before:

<img width="951" alt="Firefox_workflow_overview___Extension_Workshop" src="https://user-images.githubusercontent.com/1514/65681665-48364600-e051-11e9-8f61-78206bbf31c3.png">

After: 

<img width="952" alt="Firefox_workflow_overview___Extension_Workshop" src="https://user-images.githubusercontent.com/1514/65681704-5ab07f80-e051-11e9-94cd-b340d27e30dc.png">

Diff is easier to review with https://github.com/mozilla/extension-workshop/pull/465/files?w=1