### PR TITLE
Fix 468

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ workflows:
           filters:
             branches:
               only: master
-      - build
+      - build:
           # The filter in this step matches what's used for "deploy" step.
           # Also note that the tags filter is needed because "CircleCI does
           # not run workflows for tags unless you explicitly specify tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,16 @@ workflows:
             branches:
               only: master
       - build
+          # The filter in this step matches what's used for "deploy" step.
+          # Also note that the tags filter is needed because "CircleCI does
+          # not run workflows for tags unless you explicitly specify tag
+          # filters. Additionally, if a job requires any other jobs (directly
+          # or indirectly), you must specify tag filters for those jobs".
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v?[0-9]+(\.[0-9]+)*(?:-stage)?$/
       - deploy:
           requires:
             - build


### PR DESCRIPTION
Add a tags filter to the "build" job. The the tags filter is needed because

> CircleCI does not run workflows for tags unless you explicitly specify tag
> filters. Additionally, if a job requires any other jobs (directly or indirectly),
> you must specify tag filters for those jobs".

In our case without the tags filter, it won't run the "build" step and the "deploy"
step won't run either because the later requires the former.