### PR TITLE
Remove scroll effects for touch devices

### DIFF
--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -84,19 +84,21 @@ jQuery(document).ready(function($) {
   // **    the plugin code is found in parallax.js     **
   // *****                                         ******
 
-  if ($('.parallax').length) {
-    $('.parallax').parallax({ offsetIntertia: -0.15 });
+  if (typeof window !== 'undefined' && !('ontouchstart' in window)) {
+    console.debug('Parallax effects enabled');
+    if ($('.parallax').length) {
+      $('.parallax').parallax({ offsetIntertia: -0.15 });
+    }
+    if ($('.parallaxFG').length) {
+      $('.parallaxFG').parallaxFG({ offsetIntertia: 0.15 });
+    }
+    if ($('.parallaxFG-right').length) {
+      $('.parallaxFG-right').parallaxFG({ offsetIntertia: 0.075, axis: 'x' });
+    }
+    if ($('.parallaxFG-left').length) {
+      $('.parallaxFG-left').parallaxFG({ offsetIntertia: -0.075, axis: 'x' });
+    }
   }
-  if ($('.parallaxFG').length) {
-    $('.parallaxFG').parallaxFG({ offsetIntertia: 0.15 });
-  }
-  if ($('.parallaxFG-right').length) {
-    $('.parallaxFG-right').parallaxFG({ offsetIntertia: 0.075, axis: 'x' });
-  }
-  if ($('.parallaxFG-left').length) {
-    $('.parallaxFG-left').parallaxFG({ offsetIntertia: -0.075, axis: 'x' });
-  }
-
   // 5. Video Popup
   // ------
 
@@ -334,6 +336,16 @@ jQuery(document).ready(function($) {
   // 1.c Persistant Menu
 
   $.fn.persistantMenu = function() {
+    // Don't enable the scroll hidden menu for touch devices.
+    if (typeof window !== 'undefined' && 'ontouchstart' in window) {
+      console.debug('No-op persistantMenu for touch enabled devices');
+      return {
+        kill: function() {
+          console.debug('No-op persistantMenu.kill()');
+        },
+      };
+    }
+
     var $container = this;
     var $window = $(window);
     var scrollTop = $window.scrollTop();

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -336,16 +336,6 @@ jQuery(document).ready(function($) {
   // 1.c Persistant Menu
 
   $.fn.persistantMenu = function() {
-    // Don't enable the scroll hidden menu for touch devices.
-    if (typeof window !== 'undefined' && 'ontouchstart' in window) {
-      console.debug('No-op persistantMenu for touch enabled devices');
-      return {
-        kill: function() {
-          console.debug('No-op persistantMenu.kill()');
-        },
-      };
-    }
-
     var $container = this;
     var $window = $(window);
     var scrollTop = $window.scrollTop();


### PR DESCRIPTION
Fixes #481

This may also help #413 

## Update

This patch now only disables parallax effects for touch devices.

## Original description

This patch disabled scroll based events from working on touch devices. This means things like the menu are fixed to the top of the viewport irrespective of scrolling, trying this on a small screen seems to work ok, and it's not preventing too much of the content from being seen.

### Downsides

Landscape scrolling on a small screen isn't as good with the menus in the way.

![Screen Shot 2019-10-02 at 13 49 06](https://user-images.githubusercontent.com/1514/66045364-7fa66600-e51b-11e9-97b0-c2b1f25d4740.png)

Worst case with the browser chrome this looks like this:

![IMG_6177](https://user-images.githubusercontent.com/1514/66045672-1d019a00-e51c-11e9-919b-f0f55c46139a.png)

Which is really limited space to read. 