### PR TITLE
Fix trademark angle brackets

### DIFF
--- a/documentation/publish/add-on-policies.md
+++ b/documentation/publish/add-on-policies.md
@@ -75,7 +75,7 @@ Should an add-on include any unexpected feature that falls into one of the follo
 
 ## Content
 
-Add-ons that make use of Mozilla trademarks must comply with the [Mozilla Trademark Policy](https://www.mozilla.org/foundation/trademarks/policy/). If the add-on uses “Firefox” in its name, the naming standard the add-on is expected to follow is “<Add-on name> for Firefox”.
+Add-ons that make use of Mozilla trademarks must comply with the [Mozilla Trademark Policy](https://www.mozilla.org/foundation/trademarks/policy/). If the add-on uses “Firefox” in its name, the naming standard the add-on is expected to follow is “&lt;Add-on name&gt; for Firefox”.
 
 In addition, add-ons listed on addons.mozilla.org (AMO) must adhere to the following policies:
 


### PR DESCRIPTION
Markdown was swallowing angle brackets around "Add-on name"