### PR TITLE
Added missing "unexpected features" copy to No Surprises

### DIFF
--- a/documentation/publish/add-on-policies.md
+++ b/documentation/publish/add-on-policies.md
@@ -61,6 +61,12 @@ Should an add-on include any unexpected feature that falls into one of the follo
 - Makes unexpected changes to the browser or web content
 - Includes features or functionality not related to the add-on’s core function(s)
 
+Then the “unexpected” feature(s) must adhere to all of the following requirements:
+
+- The add-on description must clearly state what changes the add-on makes.
+- All changes must be “opt-in”, meaning the user has to take non-default action to enact the change. Changes that prompt users via the permissions system don’t require an additional opt-in.
+- The opt-in interface must clearly state the name of the add-on requesting the change.
+
 {% endcapture %}
 {% include modules/column-w-toc.html
   id="no-surprises"


### PR DESCRIPTION
We were missing a few bullet points from the No Surprises policy in the copyover from MDN. 