### PR TITLE
Refactor the nav styles for touch-based devices

### DIFF
--- a/_assets/css/_main.scss
+++ b/_assets/css/_main.scss
@@ -425,9 +425,12 @@ html {
     width: 100%;
   }
 
+  &.full-width .site-header {
+    position: fixed;
+  }
+
   &.full-width .site-header,
   &.sidebar .site-header {
-    position: fixed;
     z-index: 20;
     width: 100%;
     padding: rem-calc(6 0);
@@ -461,6 +464,7 @@ html {
 
     @include breakpoint(large) {
       padding: rem-calc(12 0);
+      position: fixed;
 
       .cell {
         position: relative;

--- a/_assets/css/_sidebar.scss
+++ b/_assets/css/_sidebar.scss
@@ -6,10 +6,6 @@ Stylesheet: Side Bar Page Stylesheet
 
 // Template Body
 
-.site.sidebar {
-  background-color: $lighter-gray;
-}
-
 // Wrapper
 
 .site.sidebar .site-wrapper {
@@ -33,81 +29,105 @@ Stylesheet: Side Bar Page Stylesheet
   }
 }
 
+.site.sidebar.scroll-menu-enabled .site-header {
+  position: fixed;
+}
+
 // Side Nav
 
 $sidebar-nav-width: rem-calc(240);
 
-.site.sidebar .sidenav {
-  ul {
-    list-style: none;
-    margin: 0;
-  }
-
-  li {
-    margin: 0;
-  }
-
-  a {
-    color: inherit;
-
-    &:hover {
-      color: $primary-color;
-    }
-  }
-
-  .is-active,
-  .has-active-children {
-    > a:hover {
-      text-decoration: none;
-    }
-  }
-
-  .primary > li:not(.is-active):not(.has-active-children) {
-    display: none;
-  }
-
-  .section {
-    display: none;
-  }
-
-  @include breakpoint(large) {
-    position: fixed;
-    top: rem-calc(64);
-    left: 0;
-    flex: 0 0 #{$sidebar-nav-width};
-    width: $sidebar-nav-width;
-    height: calc(100% - #{rem-calc(64)});
-    border-right: 1px solid $medium-light-gray;
-    overflow-y: auto;
-    overflow-x: hidden;
-    transition: top 0.4s ease-in-out, height 0.4s ease-in-out;
-  }
+.site.sidebar {
+  background-color: $lighter-gray;
 
   @include breakpoint(medium down) {
-    position: fixed;
-    z-index: 19;
-    left: 0;
-    top: rem-calc(-40);
-    padding-top: rem-calc(40);
-    transform: translateY(#{rem-calc(40)});
-    width: 100%;
-    height: rem-calc(90);
-    transition: transform 0.4s ease-in-out, height 0.4s ease-in-out;
-    overflow-y: auto;
-    background-color: $lighter-gray;
-    box-shadow: $element-shadow;
+    &:not(.scroll-menu-enabled) {
+      .site-wrapper {
+        padding-top: 0;
+      }
 
-    .primary > .is-active.has-children,
-    .primary > .has-active-children {
-      .subfolder {
-        > a {
-          display: none;
-        }
+      .sidenav {
+        position: sticky;
+        top: 0;
+      }
+    }
 
-        > li:not(.is-active):not(.has-active-children) {
-          display: none;
+    &.scroll-menu-enabled .sidenav {
+      height: rem-calc(90);
+      left: 0;
+      padding-top: rem-calc(40);
+      position: fixed;
+      top: rem-calc(-40);
+      transform: translateY(#{rem-calc(40)});
+      width: 100%;
+    }
+  }
+
+  .sidenav {
+    ul {
+      list-style: none;
+      margin: 0;
+    }
+
+    li {
+      margin: 0;
+    }
+
+    a {
+      color: inherit;
+
+      &:hover {
+        color: $primary-color;
+      }
+    }
+
+    .is-active,
+    .has-active-children {
+      > a:hover {
+        text-decoration: none;
+      }
+    }
+
+    .primary > li:not(.is-active):not(.has-active-children) {
+      display: none;
+    }
+
+    .section {
+      display: none;
+    }
+
+    @include breakpoint(medium down) {
+      background-color: $lighter-gray;
+      overflow-y: auto;
+      box-shadow: $element-shadow;
+      transition: transform 0.4s ease-in-out, height 0.4s ease-in-out;
+      z-index: 10;
+
+      .primary > .is-active.has-children,
+      .primary > .has-active-children {
+        .subfolder {
+          > a {
+            display: none;
+          }
+
+          > li:not(.is-active):not(.has-active-children) {
+            display: none;
+          }
         }
       }
+    }
+
+    @include breakpoint(large) {
+      position: fixed;
+      top: rem-calc(64);
+      left: 0;
+      flex: 0 0 #{$sidebar-nav-width};
+      width: $sidebar-nav-width;
+      height: calc(100% - #{rem-calc(64)});
+      border-right: 1px solid $medium-light-gray;
+      overflow-y: auto;
+      overflow-x: hidden;
+      transition: top 0.4s ease-in-out, height 0.4s ease-in-out;
     }
   }
 }
@@ -232,7 +252,6 @@ $sidebar-nav-width: rem-calc(240);
 
   @include breakpoint(medium down) {
     display: none;
-    border-top: 1px solid $medium-light-gray;
 
     a,
     .label {
@@ -249,7 +268,7 @@ $sidebar-nav-width: rem-calc(240);
 // Side Nav Detail Loop
 
 .site.sidebar .sidenav-detail {
-  padding-bottom: rem-calc(16);
+  padding-bottom: rem-calc(64);
   font-size: $small-font-size;
 
   a,
@@ -349,6 +368,16 @@ $sidebar-nav-width: rem-calc(240);
 
     .sidenav {
       height: 100vh;
+      width: 100%;
+      z-index: 19;
+    }
+
+    .sidenav-status {
+      top: 0;
+      position: sticky;
+      background-color: $lighter-gray;
+      border-bottom: 1px solid $medium-light-gray;
+      z-index: 10;
     }
 
     .sidenav-status::after {

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -336,6 +336,17 @@ jQuery(document).ready(function($) {
   // 1.c Persistant Menu
 
   $.fn.persistantMenu = function() {
+    // Don't enable the scroll hidden menu for touch devices.
+    if (typeof window !== 'undefined' && 'ontouchstart' in window) {
+      console.debug('No-op persistantMenu for touch enabled devices');
+      return {
+        kill: function() {
+          console.debug('No-op persistantMenu.kill()');
+        },
+      };
+    }
+
+    $('body').addClass('scroll-menu-enabled');
     var $container = this;
     var $window = $(window);
     var scrollTop = $window.scrollTop();


### PR DESCRIPTION
Fixes #481

This patch does a couple of things:

* Turns off the scroll based nav events for touch-enabled devices.
* Modifies the CSS so that position sticky is used for touch devices.

The results of this mean that the nav shows when scrolling up for non-touch devices as it did before. But for touch devices it uses sticky positioning to provide the most relevant nav at the top of the viewport during scroll. This is a compromise to avoid the issues as noted in "Downsides" here https://github.com/mozilla/extension-workshop/pull/483

### Notes for testing:

Either in a local branch or when this gets to -dev you can see the difference between touch and not-touch devices purely using the web-dev tools. Switch this icon and reload to see the differences.

Naturally this will also need to be tested on Android to ensure that the removal of scroll events helps the performance as expected. 

<img width="948" alt="Community___Extension_Workshop" src="https://user-images.githubusercontent.com/1514/66206893-4a2f8300-e6a9-11e9-8e3d-859d0d848934.png">
