### PR TITLE
Fix jumpy footer by disabling in-view for touch devices

### DIFF
--- a/_assets/css/_sidebar.scss
+++ b/_assets/css/_sidebar.scss
@@ -29,7 +29,7 @@ Stylesheet: Side Bar Page Stylesheet
   }
 }
 
-.site.sidebar.scroll-menu-enabled .site-header {
+.site.sidebar:not(.touch-device) .site-header {
   position: fixed;
 }
 
@@ -41,7 +41,7 @@ $sidebar-nav-width: rem-calc(240);
   background-color: $lighter-gray;
 
   @include breakpoint(medium down) {
-    &:not(.scroll-menu-enabled) {
+    &.touch-device {
       .site-wrapper {
         padding-top: 0;
       }
@@ -52,7 +52,7 @@ $sidebar-nav-width: rem-calc(240);
       }
     }
 
-    &.scroll-menu-enabled .sidenav {
+    &:not(.touch-device) .sidenav {
       height: rem-calc(90);
       left: 0;
       padding-top: rem-calc(40);

--- a/_assets/js/inview.js
+++ b/_assets/js/inview.js
@@ -1,5 +1,5 @@
 (function(d) {
-  if (typeof window !== 'undefined' && ('ontouchstart' in window)) {
+  if (typeof window !== 'undefined' && 'ontouchstart' in window) {
     console.debug('Inview disabled for touch device.');
     return;
   }

--- a/_assets/js/inview.js
+++ b/_assets/js/inview.js
@@ -1,4 +1,9 @@
 (function(d) {
+  if (typeof window !== 'undefined' && ('ontouchstart' in window)) {
+    console.debug('Inview disabled for touch device.');
+    return;
+  }
+
   var p = {},
     e,
     a,

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -828,7 +828,9 @@ jQuery(document).ready(function($) {
 
     // Fallback for touch devices using full-width layout.
     if (is_touch_device) {
-      $('#anatomy-of-an-extension-graphic, #anatomy-control').addClass('step-one step-two');
+      $('#anatomy-of-an-extension-graphic, #anatomy-control').addClass(
+        'step-one step-two'
+      );
     }
   };
 

--- a/_assets/js/main.js
+++ b/_assets/js/main.js
@@ -3,6 +3,7 @@
  * lance@glance.ca
  *
  */
+window.is_touch_device = 'ontouchstart' in document.documentElement;
 
 jQuery(document).ready(function($) {
   // SETTINGS
@@ -16,7 +17,9 @@ jQuery(document).ready(function($) {
   // Device
   // ------
 
-  var is_touch_device = 'ontouchstart' in document.documentElement;
+  if (is_touch_device) {
+    $('body').addClass('touch-device');
+  }
 
   $('body').on('mousedown', function() {
     $('body').addClass('using-mouse');
@@ -84,7 +87,7 @@ jQuery(document).ready(function($) {
   // **    the plugin code is found in parallax.js     **
   // *****                                         ******
 
-  if (typeof window !== 'undefined' && !('ontouchstart' in window)) {
+  if (!is_touch_device) {
     console.debug('Parallax effects enabled');
     if ($('.parallax').length) {
       $('.parallax').parallax({ offsetIntertia: -0.15 });
@@ -337,7 +340,7 @@ jQuery(document).ready(function($) {
 
   $.fn.persistantMenu = function() {
     // Don't enable the scroll hidden menu for touch devices.
-    if (typeof window !== 'undefined' && 'ontouchstart' in window) {
+    if (is_touch_device) {
       console.debug('No-op persistantMenu for touch enabled devices');
       return {
         kill: function() {
@@ -346,7 +349,6 @@ jQuery(document).ready(function($) {
       };
     }
 
-    $('body').addClass('scroll-menu-enabled');
     var $container = this;
     var $window = $(window);
     var scrollTop = $window.scrollTop();
@@ -551,6 +553,10 @@ jQuery(document).ready(function($) {
   // ------
 
   $.fn.showOnView = function(options) {
+    if (is_touch_device) {
+      console.debug('showOnView disabled for touch device');
+      return;
+    }
     var settings = $.extend(
       {
         count: 'once',
@@ -819,6 +825,11 @@ jQuery(document).ready(function($) {
         $tile_content.removeClass('hover');
         $tile_background.removeClass('hover');
       });
+
+    // Fallback for touch devices using full-width layout.
+    if (is_touch_device) {
+      $('#anatomy-of-an-extension-graphic, #anatomy-control').addClass('step-one step-two');
+    }
   };
 
   // 9. Popups


### PR DESCRIPTION
Fixes #496 

This disables the "inview" logic for touch-screen devices, furthering the removal of scroll based events.

This solves the jumpy footer issue and should also additionally improve future scrolling for touch devices. So it might also help with #495

Whilst working this I also refactored the naming of how classes + vars were used for determining when touch devices are being used to make that clearer and easier to understand.

**NOTE: don't merge until after the release this week.**
