### PR TITLE
Fixes #503: Fixed padding for landscape mode in mobile browsers

### DIFF
--- a/_assets/css/_fullwidth.scss
+++ b/_assets/css/_fullwidth.scss
@@ -30,7 +30,7 @@ Stylesheet: Full Width Page Stylesheet
   }
 
   @include breakpoint(large) {
-    height: calc(100vh - #{rem-calc(64)});
+    height: calc(100vh - #{rem-calc(72)});
     max-height: 50vw;
 
     &#top {

--- a/_assets/css/_fullwidth.scss
+++ b/_assets/css/_fullwidth.scss
@@ -23,14 +23,14 @@ Stylesheet: Full Width Page Stylesheet
   }
 
   @include breakpoint(medium) {
-    padding-top: rem-calc(64);
+    padding-top: rem-calc(72);
     height: calc(100vh - #{rem-calc(88)});
     max-height: 66vw;
     min-height: rem-calc(360);
   }
 
   @include breakpoint(large) {
-    height: calc(100vh - #{rem-calc(72)});
+    height: calc(100vh - #{rem-calc(64)});
     max-height: 50vw;
 
     &#top {

--- a/_assets/css/_fullwidth.scss
+++ b/_assets/css/_fullwidth.scss
@@ -23,6 +23,7 @@ Stylesheet: Full Width Page Stylesheet
   }
 
   @include breakpoint(medium) {
+    padding-top: rem-calc(64);
     height: calc(100vh - #{rem-calc(88)});
     max-height: 66vw;
     min-height: rem-calc(360);

--- a/documentation/develop/debugging.md
+++ b/documentation/develop/debugging.md
@@ -27,7 +27,7 @@ contributors:
     abdullahdiaa,
   ]
 last_updated_by: majordwarf
-date: 2019-14-10 17:12:00
+date: 2019-10-14 17:12:00
 ---
 
 <!-- Page Hero Banner -->

--- a/documentation/develop/debugging.md
+++ b/documentation/develop/debugging.md
@@ -7,6 +7,7 @@ topic: Develop
 tags: [Debugging, Firefox, Guide, Mozilla, WebExtensions]
 contributors:
   [
+    majordwarf,
     rebloor,
     irenesmith,
     hellosct1,
@@ -25,8 +26,8 @@ contributors:
     johnadungan,
     abdullahdiaa,
   ]
-last_updated_by: rebloor
-date: 2019-06-10 10:01:19
+last_updated_by: majordwarf
+date: 2019-14-10 17:12:00
 ---
 
 <!-- Page Hero Banner -->


### PR DESCRIPTION
Fixed the crammped header that was being caused on mobile devices when in landscape mode as mentioned here #503 

**How to test:** Fetch the PR locally > Install the dependencies > `yarn start`