### PR TITLE
Only show tags/contributors when we have some

### DIFF
--- a/_includes/page-meta-data.html
+++ b/_includes/page-meta-data.html
@@ -2,7 +2,7 @@
 	<article class="module-content grid-x grid-padding-x">
 		<div class="cell small-12">
 
-			{%- if page.tags -%}
+			{%- if page.tags and page.tags.size > 0 -%}
 				<p><span class="meta-label tags">Tags:</span>&nbsp;
 					{% for tag in page.tags %}
 					  {% capture tag_name %}{{ tag }}{% endcapture %}
@@ -11,7 +11,7 @@
 				</p>
 			{%- endif -%}
 
-			{%- if page.contributors -%}
+			{%- if page.contributors and page.contributors.size > 0 -%}
 				<p><span class="meta-label contributors">Contributors:</span>&nbsp;
 					{% for contributor in page.contributors %}
 					  <a href="https://github.com/{{ contributor }}/" title="View {{ contributor }} on Github">{{ contributor }}</a>&nbsp;
@@ -22,7 +22,7 @@
 			{%- if page.date -%}
 				<p><span class="meta-label date">Last update:</span>&nbsp;
 					{%- if page.last_updated_by -%}
-	                    <a href="https://github.com/{{ page.last_updated_by }}/" title="View {{ page.last_updated_by }} on Github" itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.last_updated_by }}</span></a>&nbsp; 
+	                    <a href="https://github.com/{{ page.last_updated_by }}/" title="View {{ page.last_updated_by }} on Github" itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.last_updated_by }}</span></a>&nbsp;
 	                {%- endif -%}
 	                <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
 	                    {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}


### PR DESCRIPTION
Fixes https://github.com/mozilla/extension-workshop/issues/515

---

Before:

![Screen Shot 2019-10-25 at 12 42 29](https://user-images.githubusercontent.com/217628/67565164-061e2400-f725-11e9-9786-121452038c7b.png)

After:

![Screen Shot 2019-10-25 at 12 42 17](https://user-images.githubusercontent.com/217628/67565165-061e2400-f725-11e9-87be-2a44c4b1d874.png)
