### PR TITLE
Sideloading deprecation

### DIFF
--- a/documentation/enterprise/enterprise-distribution.md
+++ b/documentation/enterprise/enterprise-distribution.md
@@ -85,7 +85,7 @@ This section explains how to install add-ons into Firefox using the Windows Regi
 
 {% capture alert %}
 
-Starting in Firefox 73, it will no longer be possible to have an extension be installed as part of another application installs. See the [Add-ons Blog](https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/) for more information.
+Starting in Firefox 73, it will no longer be possible to have an extension be installed as part of another application install. See the [Add-ons Blog](https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/) for more information.
 
 {% endcapture %}
 {% include modules/note.html

--- a/documentation/enterprise/enterprise-distribution.md
+++ b/documentation/enterprise/enterprise-distribution.md
@@ -85,7 +85,7 @@ This section explains how to install add-ons into Firefox using the Windows Regi
 
 {% capture alert %}
 
-Starting in Firefox 73, it will no longer be possible to have an extension be installed as part of another application install. See the [Add-ons Blog](https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/) for more information.
+Starting in Firefox 73, it will no longer be possible to have an extension be installed automatically as part of another application install. See the [Add-ons Blog](https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/) for more information.
 
 {% endcapture %}
 {% include modules/note.html

--- a/documentation/enterprise/enterprise-distribution.md
+++ b/documentation/enterprise/enterprise-distribution.md
@@ -83,6 +83,16 @@ You can sideload an add-on using one of the standard extensions folders, as desc
 
 This section explains how to install add-ons into Firefox using the Windows Registry.
 
+{% capture alert %}
+
+Starting in Firefox 73, it will no longer be possible to have an extension be installed as part of another application installs. See the [Add-ons Blog](https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/) for more information.
+
+{% endcapture %}
+{% include modules/note.html
+	content=alert
+	alert=true
+%}
+
 <!-- Alert -->
 
 {% capture alert %}

--- a/documentation/publish/distribute-for-desktop-apps.md
+++ b/documentation/publish/distribute-for-desktop-apps.md
@@ -27,18 +27,17 @@ date: 2019-07-30 02:28:37
 
 {% capture content %}
 
-If you have developed an add-on to complement a desktop application, there are several ways you can install the add-on:
+If you have developed an add-on to complement a desktop application, there are two ways you can install the add-on:
 
-- Direct the user to install from [addons.mozilla.org (AMO)](https://addons.mozilla.org) by offering a link.
-- Sideloading.
-- Using the Windows registry.
+- Direct the user to install the add-on from the web, either from [addons.mozilla.org (AMO)](https://addons.mozilla.org) or your own site.
+- Sideloading via standard extension folders or the Windows registry.
 
-Of these options, directing the user to install from AMO by offering a link is recommended. The reasons for recommending this option are:
+Of these options, directing the user to install from AMO is recommended. The reasons for recommending this option are:
 
 - It avoids any issues with the installation process; the user will not get an interstitial messages during the installation of the add-on, find the add-on installed but disabled, or find that the add-on was not installed.
-- If you update the add-on, the new version will be automatically installed, once you have uploaded it to AMO.
+- If you update the add-on, the new version will be automatically installed.
 
-By contrast, sideloading using the [standard extension folders](/documentation/publish/distribute-sideloading/#standard-extension-folders) or [Windows registry](/documentation/enterprise/enterprise-distribution/#installation-using-windows-registry) will require your desktop app to install any update to the add-on. Also, based on the default Firefox settings, the installation process will present the user with warnings (an interstitial message) or silently install the add-on but disable it. The worst case is that the installation will fail silently if [Firefox is setup to disable automatic installation](/documentation/enterprise/enterprise-distribution/#firefox-settings). You can update the [Firefox configuration](/documentation/enterprise/enterprise-distribution/#firefox-settings) to avoid these issues, but that is not recommended.
+By contrast, sideloading using the [standard extension folders](/documentation/publish/distribute-sideloading/#standard-extension-folders) or [Windows registry](/documentation/enterprise/enterprise-distribution/#installation-using-windows-registry) will require your desktop app to install any update to the add-on. As noted in these articles, these methods are deprecated and won't work in future versions of Firefox.
 
 {% endcapture %}
 {% include modules/one-column.html

--- a/documentation/publish/distribute-sideloading.md
+++ b/documentation/publish/distribute-sideloading.md
@@ -5,9 +5,9 @@ permalink: /documentation/publish/distribute-sideloading/
 published: true
 topic: Publish
 tags: [add-on, distribution, sideloading, guide, installation]
-contributors: [irenesmith, jwilk, hellosct1, gray_-_wolf, luanmm, rebloor]
-last_updated_by: hellosct1
-date: 2019-03-18 05:05:42
+contributors: [caitmuenster, irenesmith, jwilk, hellosct1, gray_-_wolf, luanmm, rebloor]
+last_updated_by: caitmuenster
+date: 2019-11-06 04:05:42
 ---
 
 <!-- Page Hero Banner -->
@@ -116,6 +116,20 @@ To use Install Add-on From File in Add-on Manager, send the user the signed add-
 {% capture content %}
 
 ## Installation using the standard extension folders
+
+<!-- Alert -->
+
+{% capture alert %}
+
+Starting in Firefox 73, it will no longer be possible to have an extension be installed as part of another application installs. See the [Add-ons Blog](https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/) for more information.
+
+{% endcapture %}
+{% include modules/note.html
+	content=alert
+	alert=true
+%}
+
+<!-- END: Alert -->
 
 This method of add-on installation involves copying the add-on into one of the standard extension folders on the user's computer. Once copied, the next time Firefox launches the add-on will be installed. By default, the user will be asked to approve the installation, and if the user approves, the add-on will be installed and automatically loaded for subsequent launches. If the user has more than one Firefox profile, the approval and installation will occur on the next launch of each profile. For details on controlling whether the user is prompted to approve the installation, see [Controlling automatic installation](/documentation/enterprise/enterprise-distribution/#controlling-automatic-installations).
 

--- a/documentation/publish/distribute-sideloading.md
+++ b/documentation/publish/distribute-sideloading.md
@@ -121,7 +121,7 @@ To use Install Add-on From File in Add-on Manager, send the user the signed add-
 
 {% capture alert %}
 
-Starting in Firefox 73, it will no longer be possible to have an extension be installed as part of another application installs. See the [Add-ons Blog](https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/) for more information.
+Starting in Firefox 73, it will no longer be possible to have an extension be automatically installed as part of another application install. See the [Add-ons Blog](https://blog.mozilla.org/addons/2019/10/31/firefox-to-discontinue-sideloaded-extensions/) for more information.
 
 {% endcapture %}
 {% include modules/note.html


### PR DESCRIPTION
Adds deprecation notice to `documentation/enterprise/enterprise-distribution/#installation-using-windows-registry` and `/documentation/publish/distribute-sideloading/#standard-extension-folders`. 

@jvillalobos, could you review this? 