### PR TITLE
Fixes 568

### DIFF
--- a/.utils/deploy.sh
+++ b/.utils/deploy.sh
@@ -121,6 +121,7 @@ for fn in $(find _site -name 'index.html' -not -path '_site/index.html'); do
     --include "*.html" \
     --metadata "{${CSP}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
     --metadata-directive "REPLACE" \
+    --website-redirect "/${s3path}/" \
     --acl "public-read" \
     $fn s3://${EXTENSION_WORKSHOP_BUCKET}/${s3path}
 done


### PR DESCRIPTION
Fixes #568

Set the x-amz-website-redirect-location property for the object that
represents the index.html file of the same named directory.

The deployment script already creates a same named object for any
directory that contains an index.html file. We now set the
x-amz-website-redirect-location property for this object so that access
to `/documentation/publish/submitting-an-add-on` for example, gets 301
redirected to `/documentation/publish/submitting-an-add-on/`.