### PR TITLE
Fixed wrong link

### DIFF
--- a/documentation/publish.md
+++ b/documentation/publish.md
@@ -64,7 +64,7 @@ Once your extension is signed, it is subject to review by Mozilla at any time. T
 There are four ways you can distribute your extension. They are:
 
 - Use [addons.mozilla.org](https://developer.mozilla.org/docs/Mozilla/Add-ons/Distribution/Submitting_an_add-on) (most popular, broadest audience)
-- Provide a [download location for the signed extension](/documentation/publish/distribute-sideloading/) file for users to self-install into Firefox.
+- Provide a [download location for the signed extension](/documentation/publish/self-distribution/) file for users to self-install into Firefox.
 - Use one of the [mechanisms designed to enable enterprise browser administrators to install add-ons](/documentation/enterprise/enterprise-distribution/)
 
 Regardless of what you choose, you’ll need to set up a developer account on [addons.mozilla.org](https://addons.mozilla.org) and host your extension to get it signed, even if you do not distribute it there. Just satisfy a few simple requirements and get your account up and running.


### PR DESCRIPTION
Fixes #631 

Repo updated with the fixing of the link for `download location for signed extension` file which previously points to the Sideloading page. 