### PR TITLE
Add element for link target

### DIFF
--- a/documentation/develop/web-ext-command-reference.md
+++ b/documentation/develop/web-ext-command-reference.md
@@ -80,6 +80,8 @@ Overwrite destination package file if it exists. Without this option, web-ext wi
 
 Environment variable: `$WEB_EXT_OVERWRITE_DEST=true`
 
+<section id="web-ext-docs"></section>
+
 ### web-ext docs
 
 Opens the [web-ext documentation](/documentation/develop/getting-started-with-web-ext/) in the user's default browser.


### PR DESCRIPTION
The added `<section id="web-ext-docs"></section>` element corrects the link with the anchor:

https://extensionworkshop.com/documentation/develop/web-ext-command-reference#web-ext-docs.

