### PR TITLE
Unify search and tag results

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -1149,7 +1149,6 @@ jQuery(document).ready(function ($) {
               '</h3><p>' +
               excerpt +
               '</p><p><small>' +
-              window.location.origin +
               item.url +
               '</small></p></a></li>';
 

--- a/src/content/tags.liquid
+++ b/src/content/tags.liquid
@@ -11,7 +11,7 @@ schemaType: webPage
 ---
 
 {% assign taglist = collections[ tag ] %}
-<h2 class="no-underline">{{ taglist.length }} Results for tag “{{ tag }}”</h2>
+<h2 class="no-underline">{{ taglist.length }} results for tag “{{ tag }}”</h2>
 <ol>
 {% for post in taglist | reverse %}
     <li class="result">

--- a/src/content/tags.liquid
+++ b/src/content/tags.liquid
@@ -10,10 +10,9 @@ permalink: /tags/{{ tag | slugify }}/
 schemaType: webPage
 ---
 
-<h2 class="no-underline">Results for tag “{{ tag }}”</h2>
-
-<ol>
 {% assign taglist = collections[ tag ] %}
+<h2 class="no-underline">{{ taglist.length }} Results for tag “{{ tag }}”</h2>
+<ol>
 {% for post in taglist | reverse %}
     <li class="result">
         <a href="{{ post.url | url }}">

--- a/src/layouts/tag-search-results.liquid
+++ b/src/layouts/tag-search-results.liquid
@@ -4,7 +4,7 @@ layout: full-width
 
 <div class="tag-results panel">
     <div class="grid-container grid-x grid-padding-x">
-        <div class="cell small-12">
+        <div class="cell small-12" id="result-list">
             {{ content }}
         </div>
     </div>


### PR DESCRIPTION
Fixes #713

This patch:

* Removes the hostname from the search results
* Adds the number of results to tag results.
* Removes the list item number from tag results and uses the same styling as search pages.

## Tags

Before: 

<img width="1729" alt="Results_for_tag__guide____Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/89526060-15b3b880-d7df-11ea-9ae9-cb06f6044cad.png">

After:

<img width="1717" alt="Results_for_tag__guide____Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/89526310-704d1480-d7df-11ea-971d-1ccf3407727c.png">


## Search results

Before: 

<img width="1698" alt="Search_Results___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/89526155-3a0f9500-d7df-11ea-891d-80b5127a736e.png">


After:

<img width="1695" alt="Search_Results___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/89526182-44ca2a00-d7df-11ea-9af2-6dc1a066e752.png">

