### PR TITLE
Fix blank space after external link icon

### DIFF
--- a/src/assets/css/_main.scss
+++ b/src/assets/css/_main.scss
@@ -75,7 +75,7 @@ main {
   a[target='_blank'] {
     &::after {
       color: inherit;
-      padding: 0 0.25em;
+      padding: 0 0 0 0.25em;
       display: inline-block;
       @include icon_font($char: $icon-newtab);
     }


### PR DESCRIPTION
Fixes #720


Before:

<img width="1018" alt="Build_a_secure_extension___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/89770583-e52d9080-daf6-11ea-95b0-2c7aa3d709a4.png">

After:

<img width="969" alt="Build_a_secure_extension___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/89770549-d9da6500-daf6-11ea-8394-7518f1b8bb2b.png">
