### PR TITLE
Move margin to right for footer links

### DIFF
--- a/src/assets/css/_main.scss
+++ b/src/assets/css/_main.scss
@@ -1019,6 +1019,10 @@ $hamburger-hover-transition-timing-function: linear;
   .mzp-c-footer-legal ul {
     @include horizontal_list($margin: 1em);
 
+    > li {
+      margin: 0 2em 0 0;
+    }
+
     margin-bottom: 1em;
 
     a {


### PR DESCRIPTION
Fixes #719

Before:

<img width="522" alt="Build_a_secure_extension___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/89771564-6cc7cf00-daf8-11ea-890a-af1b31b2ef49.png">


After:

<img width="541" alt="Build_a_secure_extension___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/89771487-4ace4c80-daf8-11ea-8caf-051b08721a8c.png">
