### PR TITLE
Tone down inline code

### DIFF
--- a/src/assets/css/_main.scss
+++ b/src/assets/css/_main.scss
@@ -259,7 +259,6 @@ code {
 
   &.nobackground {
     background: none;
-    color: $black;
   }
 
   a & {

--- a/src/assets/css/_main.scss
+++ b/src/assets/css/_main.scss
@@ -254,19 +254,21 @@ table {
 code {
   border-radius: $global-radius;
   overflow-wrap: break-word;
+  background-color: $light-gray;
+  color: $black;
 
   &.nobackground {
     background: none;
-    color: $dark-gray;
+    color: $black;
+  }
+
+  a & {
+    color: $anchor-color;
   }
 }
 
 code[class*='language-'] {
   padding: 0;
-}
-
-a code {
-  color: #00b3f4;
 }
 
 figure.highlight {


### PR DESCRIPTION
Fixes #745 

The dark background on inline code makes everything very hard to read. This patch fixes that.

Before:

<img width="1128" alt="Differences_between_desktop_and_Android_extensions___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/91290318-5faf0f00-e78b-11ea-9b99-22a782f05627.png">


After:

<img width="1169" alt="Differences_between_desktop_and_Android_extensions___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/91290161-342c2480-e78b-11ea-8c98-e8c01610bb22.png">
