### PR TITLE
docs(README): Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ published: false
 ---
 ```
 
-**NOTE:** `published: false` will withhold this content from stage and production. To publish content, remove this line.
+**ℹ️ NOTE:** `published: false` will withhold this content from stage and production. To publish content, remove this line.
 
 
 #### Add the page to the menu

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ If you would like to update content or other resources on Firefox Extension Work
 
 ## Development Guide: Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See [Deployment](#deployment) for notes on how to deploy the project on a live system.
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. 
+
+For notes on how to deploy the project on a live system, see [Deployment](#deployment).
 
 ### Prerequisites
 
@@ -27,7 +29,7 @@ To start local development, run:
 yarn start
 ```
 
-**ℹ️ NOTE:** Running locally will show unpublished content that uses the `published: false` convention in frontmatter. Content with `published: false` will not be available on stage or production.
+**ℹ️ NOTE:** Running locally will show unpublished content that uses the `published: false` convention in frontmatter. Content with `published: false` will not be available on staging or production.
 
 
 ### Available yarn commands
@@ -55,7 +57,7 @@ In development Eleventy knows nothing about the CSS and JavaScript builds. For a
 
 Building for production is slightly different. The Eleventy process and the JS and CSS builds happen in series. Then a 3rd `asset-pipeline` process initiates and takes the the built content from `./build` directory and runs it through various optimizations.
 
-In these steps the following takes place:
+During these optimizations, the following takes place:
 
 * Binary files are versioned with hashes in the file names.
 * References to these file in CSS and JS are updated.
@@ -161,16 +163,16 @@ Looks like this ![Alert Screenshot](../master/screenshots/alert.png)
 ### How to add a "sidebar" layout page
 
 1. Open `data/pages.json`.
-2. Add a node with appropriate attributes, in the appropriate location, for the new page. See below for [details on how to understand the `pages.json` structure](#understanding-the-pagejson-structure).
+2. Add a node with appropriate attributes, in the appropriate location, for the new page. See below: [Understanding the `pages.json` structure](#understanding-the-pagejson-structure).
 3. Create a new page, nested inside a folder struture that matches the URL path. For example, for permalink `/documentation/develop/best-practices-for-collecting-user-data-consents/`, you would create a file called `best-practices-for-collecting-user-data-consents.md` and place it in `documentation ▶︎ develop`.
 4. For reference on how to create a page, review the `sidebar-master-template.md` file, which lists all available modules. Some notes:
-   - `published: false` will withhold this content from stage and production. To publish content, remove this line.
+   - `published: false` will withhold this content from staging and production. To publish content, remove this line.
    - `skip_index: true` is used for pages that shouldn't be indexed for search results.
-   - When creating page sections that should be listed in the table of contents, add an `id` attribute to the section container that matches the subpageitem added to `pages.json`. If your layout requires several sections for one table of contents entry, nest your sections inside a containing element which has the `id` attribute.
+   - When creating page sections that should be listed in the table of contents, add an `id` attribute to the section container that matches the `subpageitems` entry added to `pages.json`. If your layout requires several sections for one table of contents entry, nest your sections inside a containing element which has the `id` attribute.
    - Rule for creating section `id`s: use the `h2` title of the section, converted to lowercase, spaces replaced with dashes, all non-alphanumeric characters removed. For example, the section `h2` title "Know your privacy settings" would be converted to `know-your-privacy-settings` for the section `id`.
    - The first section following the "Page Hero" module should be the "Table of Contents" module: `modules/column-w-toc.html`.
 
-<h4 id="understanding-the-pagesjson-structure">Understanding the Pages.json structure</h4>
+<h4 id="understanding-the-pagesjson-structure">Understanding the <code>pages.json</code> structure</h4>
 
 - Each page has a `title` and `url` attribute.<br>
     **ℹ️ NOTE:** The `url` attribute must exactly match the `permalink` attribute of the page's front matter _(including leading and trailing slashes)_.
@@ -303,7 +305,7 @@ published: false
 ---
 ```
 
-**ℹ️ NOTE:** `published: false` will withhold this content from stage and production. To publish content, remove this line.
+**ℹ️ NOTE:** `published: false` will withhold this content from staging and production. To publish content, remove this line.
 
 
 #### Add the page to the menu
@@ -324,21 +326,21 @@ If you don't want the page to be labelled as a draft (such as and when it's read
 
 ## Deployment
 
-All deploys for stage and prod are handled via the [releases](https://github.com/mozilla/extension-workshop/releases) page.
+All deployments for staging and production are handled via the [Releases](https://github.com/mozilla/extension-workshop/releases) page.
 
 ### Dev Deploys
 
-The site is auto-deployed on commits to `master` to https://extensionworkshop-dev.allizom.org/. You can check the version on -dev with [the dev version link](https://extensionworkshop-dev.allizom.org/__version__)
+The site is auto-deployed on commits to `master` to https://extensionworkshop-dev.allizom.org/. You can check the version on -dev with [the dev version link](https://extensionworkshop-dev.allizom.org/__version__).
 
 ### Stage Deploys
 
-Tags with a version ending in `-stage` will be deployed to https://extensionworkshop.allizom.org/. You can check the version on stage with [the stage version link](https://extensionworkshop.allizom.org/__version__)
+Tags with a version ending in `-stage` will be deployed to https://extensionworkshop.allizom.org/. You can check the version on stage with [the stage version link](https://extensionworkshop.allizom.org/__version__).
 
 A good example tag for a stage deploy would be `v2.0.1-stage`.
 
 ### Production Deploys
 
-Tags of the format `vN.N.N` will be deployed to https://extensionworkshop.com/. You can check the version on prod with [the prod version link](https://extensionworkshop.com/__version__)
+Tags of the format `vN.N.N` will be deployed to https://extensionworkshop.com/. You can check the version on production with [the production version link](https://extensionworkshop.com/__version__).
 
 A good example tag for a production deploy would be `v2.0.1`.
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ General overview of the `pages.json` layout:
 #### Create a new page
 
 1. Create new file
-2. Add header (see example below)
+2. Add frontmatter (see example below)
 3. Copy 'modules' needed from `content-guidelines/master-template.md` and paste in new file
 4. Save as markdown: `content-guidelines/page-name.md`
 
@@ -308,17 +308,19 @@ published: false
 
 #### Add the page to the menu
 
-Go to `data/content-guidelines-pages.yaml` and add a new entry for your page:
+Go to `data/content-guidelines-pages.json` and add a new entry for your page:
 
-```yaml
-- title: "Page Name"
-  url: "/content-guidelines/page-name/"
-  draft-label: true
+```json
+{
+  "title": "Page Name",
+  "url": "/content-guidelines/page-name/",
+  "draft-label": true
+}
 ```
 
 #### Controlling draft labelling
 
-If you don't want the page to be labelled as a draft (such as and when it's ready), remove `draft-label: true` from the relevant entry in `data/content-guidelines-pages.json`.
+If you don't want the page to be labelled as a draft (such as and when it's ready), remove `"draft-label": true` from the relevant entry in `data/content-guidelines-pages.json`.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To start local development, run:
 yarn start
 ```
 
-**NOTE:** Running locally will show unpublished content that uses the `published: false` convention in frontmatter. Content with `published: false` will not be available on stage or production.
+**ℹ️ NOTE:** Running locally will show unpublished content that uses the `published: false` convention in frontmatter. Content with `published: false` will not be available on stage or production.
 
 
 ### Available yarn commands
@@ -173,10 +173,10 @@ Looks like this ![Alert Screenshot](../master/screenshots/alert.png)
 <h4 id="understanding-the-pagesjson-structure">Understanding the Pages.json structure</h4>
 
 - Each page has a `title` and `url` attribute.
-    **NOTE:** The `url` attribute must exactly match the `permalink` attribute of the page's front matter _(including leading and trailing slashes)_.
+    **ℹ️ NOTE:** The `url` attribute must exactly match the `permalink` attribute of the page's front matter _(including leading and trailing slashes)_.
 - Pages may also have a `subpageitems` node for sections within the page to be referenced in the table of contents for that page:
   - Each `subpageitem` node has a `title` and `id` attribute. The value of `id` matches the `id` attribute of the section container.
-    (**Note:** `id`s must be added to the containing element, rather than the heading element, of the section. This ensures that highlighting for the section remains active, even when the section title is out of view.)
+    (**ℹ️ NOTE:** `id`s must be added to the containing element, rather than the heading element, of the section. This ensures that highlighting for the section remains active, even when the section title is out of view.)
 - Overview pages have `category` nodes for each of their contained (sub) `categories`.
 - Categories have a `category` attibute (which denotes the category title), and a `pages` attribute (which lists sub-pages of the overview page).
 - The Documentation Topics section pages are nested inside a `subfolderitems` node, which creates the dropdown panel.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you would like to update content or other resources on Firefox Extension Work
 
 ## Development Guide: Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See [Deployment](#deployment) for notes on how to deploy the project on a live system.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to Firefox Extension Workshop, a launchpad for building Firefox extensio
 
 ## Updating Content
 
-If you would like to update content or other resources on Firefox Extension Workshop, please refer to [contributing.md](.github/contributing.md)
+If you would like to update content or other resources on Firefox Extension Workshop, please refer to [`contributing.md`](.github/contributing.md)
 
 ## Development Guide: Getting Started
 
@@ -21,26 +21,27 @@ These instructions will get you a copy of the project up and running on your loc
 yarn install
 ```
 
-Then to run locally in devlopment run:
+To start local development, run:
 
 ```
 yarn start
 ```
 
-Note: Running locally will show unpublished content that uses the `published: false` convention in frontmatter. Content with `published: false` will not be available on stage or production.
+**NOTE:** Running locally will show unpublished content that uses the `published: false` convention in frontmatter. Content with `published: false` will not be available on stage or production.
+
 
 ### Available yarn commands
 
 | Command                | Description                                                                             |
 | ---------------------- | --------------------------------------------------------------------------------------- |
-| yarn start             | Starts eleventy and includes unpublished content.                                       |
-| yarn build:production  | Builds the site for production.                                                         |
-| yarn build:unpublished | Builds the site for production with unpublished content.                                |
-| yarn clean             | Clears the output directory. (You probably won't need to use this manually)             |
+| `yarn start`             | Starts eleventy and includes unpublished content.                                       |
+| `yarn build:production`  | Builds the site for production.                                                         |
+| `yarn build:unpublished` | Builds the site for production with unpublished content.                                |
+| `yarn clean`             | Clears the output directory. (You probably won't need to use this manually.)             |
 
 ## How the site is built
 
-The site is built with [Eleventy](https://www.11ty.dev/) which is a nodejs based static site generator.
+The site is built with [Eleventy](https://www.11ty.dev/), a NodeJS-based static site generator.
 
 The site works in slightly different ways depending on whether you're running the site for local development or building the site for production.
 
@@ -52,28 +53,32 @@ In development Eleventy knows nothing about the CSS and JavaScript builds. For a
 
 ### Production builds
 
-Building for production is slightly different. The Eleventy process and the JS and CSS builds happen in series. Then a 3rd `asset-pipeline` process happens which takes the the built content from `./build` directoty and runs it through various optimizations.
+Building for production is slightly different. The Eleventy process and the JS and CSS builds happen in series. Then a 3rd `asset-pipeline` process initiates and takes the the built content from `./build` directory and runs it through various optimizations.
 
 In these steps the following takes place:
 
 * Binary files are versioned with hashes in the file names.
 * References to these file in CSS and JS are updated.
-* CSS and JS are minified
+* CSS and JS are minified.
 * The HTML is processed to update the references to the assets new hash-based filenames.
 
-All of this means that we can serve the site with far-future expires headers. If the resource is in the browser's cache it won't even make a request for it. To break the cache the resource's url needs to change. When something ie updated and the script re-run the hash in the filename will change, which won't be ccached and the browser will know to fetch it. This helps the site be fast.
+All of this means that we can serve the site with far-future `Expires` headers. If the resource is in the browser's cache, the browser won't even make a request for it. To break the cache, the resource's URL needs to change. When something is updated and the script is re-run, the hash in the filename will change, so the new filename won't be cached and the browser will know to fetch it. This helps the site be fast.
 
-Whilst the `asset-pipline` script is custom, it leverages a lot of existing libs where possible, these include Terser, postHTML, postCSS and various plugins.
+Whilst the `asset-pipline` script is custom, it leverages a lot of existing libs where possible, these include Terser, postHTML, postCSS, and various plugins.
 
-At some point it's likely 11ty will have its own mechanism for wrangling assets and at that point this will no longer be required.
+It's likely that some day, 11ty will have its own mechanism for wrangling assets. At that point, this will no longer be required.
 
 #### Asset paths
 
-For the asset-pipeline script to do it's thing, all you need to do is refer to all assets with a path beginning with `/assets/` if you do that, everything else is handled for you ✨
+For the `asset-pipeline` script to do its thing, all you need to do is refer to all assets with a path beginning with `/assets/`. If you do that, everything else is handled for you ✨
 
 ## Development Guide: Content Updates
 
-This site has three templates: a full-width page, a sidebar page for documentation, and a Content Guidelines page
+This site has three templates: 
+
+1. A full-width page
+2. A sidebar "page" for documentation
+3. A Content Guidelines page
 
 ### Repo layout
 
@@ -123,7 +128,7 @@ extensionworkshop.com
 1. Add the image files to `src/assets/img/`
 2. In your page, link to images using this page structure:
 
-You can reference images with the full path from the assets directory e.g: `/assets/img/image.png`
+You can reference images with the full path from the `assets/` directory (e.g, `/assets/img/image.png`).
 
 Here's an example in `markdown`:
 
@@ -133,46 +138,50 @@ Here's an example in `markdown`:
 
 ### Adding notes and alerts
 
-For a note use the markdown syntax extensions as follows (these are supplied via a plugin to the markdown renderer):
+For a note, use the markdown syntax extensions as follows. (These markdown extensions are supplied by a plugin to the markdown renderer.)
 
 ```markdown
 ::: note
 This is a note
 :::
 ```
+
 Looks like this ![Note Screenshot](../master/screenshots/note.png)
 
-For an alert use the following:
+For an alert, use the following:
 
 ```markdown
 ::: note alert
 This is an alert
 :::
 ```
+
 Looks like this ![Alert Screenshot](../master/screenshots/alert.png)
 
 ### How to add a "sidebar" layout page
 
 1. Open `data/pages.json`.
-2. Add a node with appropriate attributes, in the appropriate location, for the new page. See below for [details on how to understand the pages.json structure](#understanding-the-pagejson-structure).
-3. Create a new page, nested inside a folder struture that matches the url path. For example, for permalink `/documentation/develop/best-practices-for-collecting-user-data-consents/`, you would create a file called `best-practices-for-collecting-user-data-consents.md` and place it in `documentation` > `develop`.
+2. Add a node with appropriate attributes, in the appropriate location, for the new page. See below for [details on how to understand the `pages.json` structure](#understanding-the-pagejson-structure).
+3. Create a new page, nested inside a folder struture that matches the URL path. For example, for permalink `/documentation/develop/best-practices-for-collecting-user-data-consents/`, you would create a file called `best-practices-for-collecting-user-data-consents.md` and place it in `documentation ▶︎ develop`.
 4. For reference on how to create a page, review the `sidebar-master-template.md` file, which lists all available modules. Some notes:
-   - `published: false` will withhold this content from stage and production, to publish content, remove this line.
+   - `published: false` will withhold this content from stage and production. To publish content, remove this line.
    - `skip_index: true` is used for pages that shouldn't be indexed for search results.
-   - When creating page sections that will be listed in the table of contents, add an ID attribute to the section container that matches the subpageitem added to Pages.yaml. If your layout requires several sections for one table of contents entry, nest your sections inside a containing element which has the ID attribute.
-   - Rull for creating section IDs: use the `h2` title of the section, converted to lowercase, spaces replaced with dashes, all non-alphanumeric characters removed. For example, the section `h2` title "Know your privacy settings" would be converted to `know-your-privacy-settings` for the section ID
+   - When creating page sections that should be listed in the table of contents, add an `id` attribute to the section container that matches the subpageitem added to `pages.json`. If your layout requires several sections for one table of contents entry, nest your sections inside a containing element which has the `id` attribute.
+   - Rule for creating section `id`s: use the `h2` title of the section, converted to lowercase, spaces replaced with dashes, all non-alphanumeric characters removed. For example, the section `h2` title "Know your privacy settings" would be converted to `know-your-privacy-settings` for the section `id`.
    - The first section following the "Page Hero" module should be the "Table of Contents" module: `modules/column-w-toc.html`.
 
 <h4 id="understanding-the-pagesjson-structure">Understanding the Pages.json structure</h4>
 
-- Each new page has a title and url attribute _**Note:** The url attribute must match exactly the permalink attribute of the page's front matter (including leading and trailing slashes)_
-- Pages can also have a subpageitems node for sections within the page to be referenced in the table of contents for that page:
-  - Each subpageitem node has a title and ID attribute, where the ID matches the ID attribute of the section container _(IDs need to be added to a containing element, rather than the heading element, of the section. This is so that highlighting for that section stays active even when the section title is out of view)_
-- Overview pages have category nodes for each of the sub categories for that section
-- Categories have a category attibute which denotes the category title, and a pages attribute where sub pages of the overview page are listed
-- The Documentation Topics section pages are nested inside a `subfolderitems` node, which creates the dropdown panel
+- Each page has a `title` and `url` attribute.
+    **NOTE:** The `url` attribute must exactly match the `permalink` attribute of the page's front matter _(including leading and trailing slashes)_.
+- Pages may also have a `subpageitems` node for sections within the page to be referenced in the table of contents for that page:
+  - Each `subpageitem` node has a `title` and `id` attribute. The value of `id` matches the `id` attribute of the section container.
+    (**Note:** `id`s must be added to the containing element, rather than the heading element, of the section. This ensures that highlighting for the section remains active, even when the section title is out of view.)
+- Overview pages have `category` nodes for each of their contained (sub) `categories`.
+- Categories have a `category` attibute (which denotes the category title), and a `pages` attribute (which lists sub-pages of the overview page).
+- The Documentation Topics section pages are nested inside a `subfolderitems` node, which creates the dropdown panel.
 
-General overview of the pages layout:
+General overview of the `pages.json` layout:
 
 ```json
 [
@@ -285,7 +294,7 @@ General overview of the pages layout:
 3. Copy 'modules' needed from `content-guidelines/master-template.md` and paste in new file
 4. Save as markdown: `content-guidelines/page-name.md`
 
-```
+```yaml
 ---
 layout: guides
 title: Page Name
@@ -294,13 +303,14 @@ published: false
 ---
 ```
 
-Note: `published: false` will withhold this content from stage and production, to publish content, remove this line.
+**NOTE:** `published: false` will withhold this content from stage and production. To publish content, remove this line.
+
 
 #### Add the page to the menu
 
 Go to `data/content-guidelines-pages.yaml` and add a new entry for your page:
 
-```
+```yaml
 - title: "Page Name"
   url: "/content-guidelines/page-name/"
   draft-label: true
@@ -308,7 +318,7 @@ Go to `data/content-guidelines-pages.yaml` and add a new entry for your page:
 
 #### Controlling draft labelling
 
-If you don't want the page to be labelled as a draft, as and when it's ready remove `draft-label: true` from the relevant entry in `data/content-guidelines-pages.json`
+If you don't want the page to be labelled as a draft (such as and when it's ready), remove `draft-label: true` from the relevant entry in `data/content-guidelines-pages.json`.
 
 ## Deployment
 
@@ -316,20 +326,20 @@ All deploys for stage and prod are handled via the [releases](https://github.com
 
 ### Dev Deploys
 
-The site is auto-deployed on commits to master to https://extensionworkshop-dev.allizom.org/. You can check the version on -dev with [the dev version link](https://extensionworkshop-dev.allizom.org/__version__)
+The site is auto-deployed on commits to `master` to https://extensionworkshop-dev.allizom.org/. You can check the version on -dev with [the dev version link](https://extensionworkshop-dev.allizom.org/__version__)
 
 ### Stage Deploys
 
 Tags with a version ending in `-stage` will be deployed to https://extensionworkshop.allizom.org/. You can check the version on stage with [the stage version link](https://extensionworkshop.allizom.org/__version__)
 
-A good example of a tag for stage would be `v2.0.1-stage`.
+A good example tag for a stage deploy would be `v2.0.1-stage`.
 
 ### Production Deploys
 
 Tags of the format `vN.N.N` will be deployed to https://extensionworkshop.com/. You can check the version on prod with [the prod version link](https://extensionworkshop.com/__version__)
 
-A good example tag would be `v2.0.1`.
+A good example tag for a production deploy would be `v2.0.1`.
 
 ### Version numbers
 
-Tag versions should aim to follow follow the [semver](https://semver.org/) format.
+Tag versions should aim to follow the [semver](https://semver.org/) format.

--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ Looks like this ![Alert Screenshot](../master/screenshots/alert.png)
 
 <h4 id="understanding-the-pagesjson-structure">Understanding the Pages.json structure</h4>
 
-- Each page has a `title` and `url` attribute.
+- Each page has a `title` and `url` attribute.<br>
     **ℹ️ NOTE:** The `url` attribute must exactly match the `permalink` attribute of the page's front matter _(including leading and trailing slashes)_.
 - Pages may also have a `subpageitems` node for sections within the page to be referenced in the table of contents for that page:
-  - Each `subpageitem` node has a `title` and `id` attribute. The value of `id` matches the `id` attribute of the section container.
+  - Each `subpageitem` node has a `title` and `id` attribute. The value of `id` matches the `id` attribute of the section container.<br>
     (**ℹ️ NOTE:** `id`s must be added to the containing element, rather than the heading element, of the section. This ensures that highlighting for the section remains active, even when the section title is out of view.)
 - Overview pages have `category` nodes for each of their contained (sub) `categories`.
 - Categories have a `category` attibute (which denotes the category title), and a `pages` attribute (which lists sub-pages of the overview page).


### PR DESCRIPTION
- Fix several typos
- Fix outdated references to `*.yaml` files that are now `*.json` (and associated example code)
- Assorted copy-edits throughout (for formatting, phrasing, and clarity)