### PR TITLE
Add security note about dompurify

### DIFF
--- a/src/content/documentation/develop/build-a-secure-extension.md
+++ b/src/content/documentation/develop/build-a-secure-extension.md
@@ -37,7 +37,7 @@ Here is a list of best practices you should follow to keep the users of your ext
 
   - insert strings using safe native DOM manipulation methods: [`document.createElement()`](https://developer.mozilla.org/docs/Web/API/Document/createElement), [`Element.setAtttribute()`](https://developer.mozilla.org/docs/Web/API/Element/setAttribute), and [`Node.textContent`](https://developer.mozilla.org/docs/Web/API/Node/textContent).
   - use jQuery functions `attr()` and `text()` to insert strings.
-  - sanitize HTML content with  [DOMPurify](https://github.com/cure53/DOMPurify) version 2.0.7+. (Note: DOMPurify versions 2.0.6 and older contain a cross-site-scripting security vulnerability.)
+  - sanitize HTML content with  [DOMPurify](https://github.com/cure53/DOMPurify) version 2.0.7+. (Note: DOMPurify versions 2.0.6 and older contain a cross-site scripting security vulnerability.)
   - use templating engine commands that escape any HTML before inserting it.
 
   For more information, see [Safely inserting external content into a page](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page).

--- a/src/content/documentation/develop/build-a-secure-extension.md
+++ b/src/content/documentation/develop/build-a-secure-extension.md
@@ -37,7 +37,7 @@ Here is a list of best practices you should follow to keep the users of your ext
 
   - insert strings using safe native DOM manipulation methods: [`document.createElement()`](https://developer.mozilla.org/docs/Web/API/Document/createElement), [`Element.setAtttribute()`](https://developer.mozilla.org/docs/Web/API/Element/setAttribute), and [`Node.textContent`](https://developer.mozilla.org/docs/Web/API/Node/textContent).
   - use jQuery functions `attr()` and `text()` to insert strings.
-  - sanitize HTML content with  [DOMPurify](https://github.com/cure53/DOMPurify).
+  - sanitize HTML content with  [DOMPurify](https://github.com/cure53/DOMPurify) version 2.0.7+. (Note: DOMPurify versions 2.0.6 and older contain a cross-site-scripting security vulnerability.)
   - use templating engine commands that escape any HTML before inserting it.
 
   For more information, see [Safely inserting external content into a page](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page).
@@ -86,5 +86,3 @@ Here is a list of best practices you should follow to keep the users of your ext
 </section>
 
 <!-- END: Single Column Body Module -->
-
-


### PR DESCRIPTION
- We've learned that there's a security vulnerability for DOMPurify versions 2.0.6 and older; we've updated our advice to recommend using versions 2.0.7+. 