### PR TITLE
Add !important to avoid override via overspecified other rules

### DIFF
--- a/src/assets/css/_main.scss
+++ b/src/assets/css/_main.scss
@@ -2187,7 +2187,7 @@ span.example {
 
 .note {
   position: relative;
-  padding: rem-calc(10 15 10 38);
+  padding: rem-calc(10 15 10 38) !important;
   font-size: $small-font-size;
   border-left: #{rem-calc(2)} solid $warning-color;
   background-color: $warning-color-light;


### PR DESCRIPTION
Fixes #770

Yes, using `!important` is gross but the overriding rules are very highly-specified.

Before: 
<img width="1354" alt="Developing_extensions_for_Firefox_for_Android___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/93492284-8aabff00-f902-11ea-986b-e21c646751df.png">

After:

<img width="1408" alt="Developing_extensions_for_Firefox_for_Android___Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/93492326-94cdfd80-f902-11ea-9a3d-209d75d13658.png">

