### PR TITLE
Update monitoring extension usage statistics page

### DIFF
--- a/src/content/documentation/manage/monitoring-extension-usage-statistics.md
+++ b/src/content/documentation/manage/monitoring-extension-usage-statistics.md
@@ -83,7 +83,7 @@ If you link to your add-on’s listing page you can append the following [standa
 %}
 
 ::: note
-The statistics dashboard will only counted installs from the AMO listing page. Installs from other sources, such as .xpi downloads from a website or blog, are not counted on the dashboard. 
+The statistics dashboard will only count installs from the AMO listing page. Installs from other sources, such as .xpi downloads from a website or blog, are not counted on the dashboard. 
 :::
 
 <!-- END: Table -->

--- a/src/content/documentation/manage/monitoring-extension-usage-statistics.md
+++ b/src/content/documentation/manage/monitoring-extension-usage-statistics.md
@@ -64,7 +64,7 @@ The easiest way to access the dashboard is to sign in to AMO and navigate to “
 
 # Tracking external sources
 
-If you link to your add-on’s listing page or directly to its file from an external site, such as your blog or website, you can append the following [standard UTM parameters](https://en.wikipedia.org/wiki/UTM_parameters) to be tracked as additional sources on your download statistics dashboard:
+If you link to your add-on’s listing page you can append the following [standard UTM parameters](https://en.wikipedia.org/wiki/UTM_parameters) to be tracked as additional sources on your download statistics dashboard:
 
 <!-- Table -->
 
@@ -81,6 +81,10 @@ If you link to your add-on’s listing page or directly to its file from an exte
 {% include modules/table.liquid
 	content: table
 %}
+
+::: note
+The statistics dashboard will only counted installs from the AMO listing page. Installs from other sources, such as .xpi downloads from a website or blog, are not counted on the dashboard. 
+:::
 
 <!-- END: Table -->
 

--- a/src/content/documentation/manage/monitoring-extension-usage-statistics.md
+++ b/src/content/documentation/manage/monitoring-extension-usage-statistics.md
@@ -83,7 +83,7 @@ If you link to your add-on’s listing page you can append the following [standa
 %}
 
 ::: note
-The statistics dashboard will only count installs from the AMO listing page. Installs from other sources, such as .xpi downloads from a website or blog, are not counted on the dashboard. 
+The statistics dashboard will only count installs from the AMO listing page. Installs from other sources, such as .xpi downloads from a website or blog, are not counted on the dashboard, even if they link to an XPI hosted on AMO. 
 :::
 
 <!-- END: Table -->


### PR DESCRIPTION
Clarify that the AMO stats dashboard only counts installs from the AMO listing page, not downloads of self-distributed files from non-AMO sources. 