### PR TITLE
Remove references to dev-addons mailing list

### DIFF
--- a/src/content/community.md
+++ b/src/content/community.md
@@ -5,7 +5,7 @@ permalink: /community/
 tags: [community, contribute, webextensions]
 contributors: [caitmuenster, grlwholifts]
 author: caitmuenster
-date: 2020-03-06 09:00:00
+date: 2020-12-03 
 ---
 
 <!-- Overview Page Hero Banner -->
@@ -51,10 +51,6 @@ There are several ways to stay up-to-date with Firefox add-on technology and con
 ### Add-ons blog
 
 Stay up to date with the latest information about add-on technology on the [Add-ons blog](https://blog.mozilla.org/addons).
-
-### Email list
-
-Subscribe to our [mailing list](https://mail.mozilla.org/listinfo/dev-addons) dedicated to the development of the add-on ecosystem, including the site addons.mozilla.org (AMO), WebExtensions APIs, and public meetings.
 
 ### Questions about add-on development
 

--- a/src/includes/connect.liquid
+++ b/src/includes/connect.liquid
@@ -13,7 +13,7 @@
         <div class="cell small-12 large-4">
             <h4>More</h4>
             <p><a href="https://wiki.mozilla.org/Matrix" class="irc">Matrix</a></p>
-            <p><a href="https://mail.mozilla.org/listinfo/dev-addons" class="mailinglist">Add-on Developers Mailing List</a></p>
+            <p><a href="https://discourse.mozilla.org/c/add-ons/" class="irc">Community forum</a></p>
         </div>
         <div class="cell small-12 large-5">
             <h4>Extensions Developer Newsletter</h4>


### PR DESCRIPTION
Fixes #846. 

Removes references to the dev-addons mailing list from the "Connect with Us" footer and the Community page. 