### PR TITLE
Fix missing line breaks

### DIFF
--- a/src/content/documentation/develop/getting-started-with-web-ext.md
+++ b/src/content/documentation/develop/getting-started-with-web-ext.md
@@ -267,6 +267,7 @@ web-ext sign --api-key=... --api-secret=... --id="{c23c69a7-f889-447c-9d6b-7694b
 ```
 
 <section id="restricted-environment"></section>
+
 ### Signing in a restricted environment
 
 If you're working in an environment that restricts access to certain domains, you can try using a proxy when signing:
@@ -283,6 +284,7 @@ The following domains are used for signing and downloading files:
 - `addons.cdn.mozilla.net`
 
 <section id="signing-test-version-listed"></section>
+
 ### Signing a test version of a listed extension
 
 If you've [listed](/documentation/publish/submitting-an-add-on/) an extension on [addons.mozilla.org](https://addons.mozilla.org/), use `web-ext` to create a signed but [unlisted](/documentation/publish/self-distribution/) version for testing purposes. For example, you may wish to distribute an alpha or beta version to users for early feedback and testing.
@@ -323,6 +325,7 @@ This uses the [addons-linter](https://github.com/mozilla/addons-linter) library 
 See the [lint reference guide](/documentation/develop/web-ext-command-reference/#web-ext-lint) to learn more.
 
 <section id="setting-option-defaults-in-a-configuration-file"></section>
+
 ### Setting option defaults in a configuration file
 
 You can specify `--config=my-config.js` to set default values for any option. Here is an example with the `build` command:

--- a/tests/section.test.js
+++ b/tests/section.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs-extra');
+const glob = require('glob');
+
+/*
+ * Tests to mitigate issues with headings not being displayed due
+ * to incorrect formatting. This should be a test failure:
+ *
+ * ```
+ * <section>
+ * ### A Heading
+ * ```
+ *
+ * This would not:
+ *
+ * ```
+ * <section>
+ *
+ * ### Another heading
+ *```
+ */
+describe('section heading test', () => {
+  for (const mdFile of glob.sync('src/content/**/*.md')) {
+    it(`${mdFile} should not have sections next to headings without a new line`, async () => {
+      const mdFileContent = await fs.readFile(mdFile, 'utf8');
+      expect(mdFileContent).not.toMatch(/<\/section>(?:\r|\n|\r\n)#{1,6} .*$/m);
+    });
+  }
+});


### PR DESCRIPTION
This takes the PR from #894 and adds a regression test to catch it if it comes up again in the future.

The test fails without the patch.