### PR TITLE
Fix missing up next tiles

### DIFF
--- a/src/includes/up-next.liquid
+++ b/src/includes/up-next.liquid
@@ -12,7 +12,7 @@
         {% if on_current_page == true %}
             {% assign next_page_ar = collections.all | where: 'data.permalink', item.url %}
             {% for next_page in next_page_ar %}
-                {% if is_next_range < max_steps and next_page.data.skip_index %}
+                {% if is_next_range < max_steps and next_page.data.skip_index != true %}
                     {%- include up-next-tile.liquid -%}
                 {% endif %}
                 {% assign is_next_range = is_next_range | plus: 1 %}
@@ -30,7 +30,7 @@
                     {% if on_current_page == true %}
                         {% assign next_page_ar = collections.all | where: 'data.permalink', pg.url %}
                         {% for next_page in next_page_ar %}
-                            {% if is_next_range < max_steps and next_page.data.skip_index %}
+                            {% if is_next_range < max_steps and next_page.data.skip_index != true %}
                                 {% include up-next-tile.liquid %}
                             {% endif %}
                             {% assign is_next_range = is_next_range | plus: 1 %}
@@ -49,7 +49,7 @@
                 {% if on_current_page == true %}
                     {% assign next_page_ar = collections.all | where: 'data.permalink', subitem.url %}
                     {% for next_page in next_page_ar %}
-                        {% if is_next_range < max_steps and next_page.data.skip_index %}
+                        {% if is_next_range < max_steps and next_page.data.skip_index != true %}
                             {%- include up-next-tile.liquid -%}
                         {% endif %}
                         {% assign is_next_range = is_next_range | plus: 1 %}
@@ -67,7 +67,7 @@
                             {% if on_current_page == true %}
                                 {% assign next_page_ar = collections.all | where: 'data.permalink', pg.url %}
                                 {% for next_page in next_page_ar %}
-                                    {% if is_next_range < max_steps and next_page.data.skip_index %}
+                                    {% if is_next_range < max_steps and next_page.data.skip_index != true %}
                                         {%- include up-next-tile.liquid -%}
                                     {% endif  %}
                                     {% assign is_next_range = is_next_range | plus: 1 %}
@@ -85,7 +85,7 @@
                 {% if on_current_page == true %}
                     {% assign next_page_ar = collections.all | where: 'data.permalink', subitem.url %}
                     {% for next_page in next_page_ar %}
-                        {% if is_next_range < max_steps and next_page.data.skip_index %}
+                        {% if is_next_range < max_steps and next_page.data.skip_index != true %}
                             {%- include up-next-tile.liquid -%}
                         {% endif %}
                         {% assign is_next_range = is_next_range | plus: 1 %}
@@ -102,7 +102,7 @@
         {% if on_current_page == true %}
             {% assign next_page_ar = collections.all | where: 'data.permalink', item.url %}
             {% for next_page in next_page_ar %}
-                {% if is_next_range < max_steps and next_page.data.skip_index %}
+                {% if is_next_range < max_steps and next_page.data.skip_index != true %}
                     {%- include up-next-tile.liquid -%}
                 {% endif %}
                 {% assign is_next_range = is_next_range | plus: 1 %}


### PR DESCRIPTION
Fixes #943

* Switching `&&` to `and` caused the logic to break resulting in the up-next tiles disappearing.
* With the template logic in this patch, a page with `skip_index: true` in the frontmatter will be not be featured in the up-next tile list. AFAICT this condition was never met before anyway see below for more info... 

The original Jekyll template logic had `next_page.skip_index != false` (the data different is related to frontmatter differences) - what is weird is that this looks like the inverse to the logic in this patch.

The error parsing `&&` was introduced in (v9.23.0)[https://github.com/harttle/liquidjs/compare/v9.22.1...v9.23.0]. But maybe `&&` was invalid but was ignored?

Looking at the docs, for both the original liquid and liquid JS there's no reference to `&&` as an operator, only `and`. So whilst this might have not caused an error (until now) it looks to be an error that has propagated from the original Jekyll templating.

The good news is diffing the prod build from this branch and the one prior to the liquid update results in identical output.