### PR TITLE
Clarify how the add-on package can be tested

### DIFF
--- a/src/content/documentation/develop/temporary-installation-in-firefox.md
+++ b/src/content/documentation/develop/temporary-installation-in-firefox.md
@@ -16,9 +16,10 @@ contributors:
     andrewtruongmoz,
     hellosct1,
     kumar303,
+    Rob--W,
   ]
-last_updated_by: mdnwebdocs-bot
-date: 2019-12-19 08:45:00
+last_updated_by: Rob--W
+date: 2021-04-27
 ---
 
 <!-- Page Hero Banner -->
@@ -48,7 +49,8 @@ To install an extension temporarily:
 - enter "`about:debugging`" in the URL bar
 - click "This Firefox"
 - click "Load Temporary Add-on"
-- open the extension's directory and select any file inside the extension.
+- open the extension's directory and select any file inside the extension,
+  or select the [packaged extension (.zip file)](/documentation/publish/package-your-extension/).
 
 The extension installs and remains installed until you remove it or restart Firefox.
 

--- a/src/content/documentation/publish/package-your-extension.md
+++ b/src/content/documentation/publish/package-your-extension.md
@@ -18,9 +18,10 @@ contributors:
     wbamberg,
     mrj,
     mickro,
+    Rob--W,
   ]
-last_updated_by: mickro
-date: 2020-04-26
+last_updated_by: Rob--W
+date: 2021-04-27
 ---
 
 <!-- Page Hero Banner -->
@@ -51,6 +52,10 @@ The most convenient way to package your extension is to use [`web-ext build`](/d
 
 ::: note
 **Tip:** The ZIP file must be a ZIP of the extension's files themselves, not of the directory containing them.
+:::
+
+::: note
+**Tip:** Verify that the ZIP file is formatted correctly, for example by [loading the file at `about:debugging` in Firefox](/documentation/develop/temporary-installation-in-firefox/).
 :::
 
 {% endcapture %}


### PR DESCRIPTION
Documentation for https://github.com/mozilla/FirefoxColor/issues/971

This expansion of the documentation supports https://github.com/mozilla/FirefoxColor/pull/975