### PR TITLE
Fix wrong utm_campaign parameter

### DIFF
--- a/src/content/documentation/manage/monitoring-extension-usage-statistics.md
+++ b/src/content/documentation/manage/monitoring-extension-usage-statistics.md
@@ -110,7 +110,7 @@ There is a limit of 40 characters for each UTM parameter value. Longer values wi
 
 Below is an example of a link to your add-on's listing page with UTM parameters:
 
-`https://addons.mozilla.org/addon/firefox-color?utm_source=mysite.wordpress.com&utm_medium=blog&utm_content=top-banner&campaign=get-my-addons`
+`https://addons.mozilla.org/addon/firefox-color?utm_source=mysite.wordpress.com&utm_medium=blog&utm_content=top-banner&utm_campaign=get-my-addons`
 
 {% endcapture %}
 {% include modules/one-column.liquid


### PR DESCRIPTION
It’s likely a typo that you missed the ` utm_`  prefix there, which makes the mentioned example unusable. :slightly_smiling_face: