### PR TITLE
Updates to Publish docs

### DIFF
--- a/src/content/documentation/publish.md
+++ b/src/content/documentation/publish.md
@@ -5,7 +5,7 @@ permalink: /documentation/publish/
 tags: []
 contributors: [caitmuenster]
 last_updated_by: caitmuenster
-date: 2019-07-09 09:00:00
+date: 2021-09-13 
 ---
 
 <!-- Overview Page Hero Banner -->
@@ -30,15 +30,13 @@ Learn how to get your extension signed and distributed worldwide or to your ente
 
 ## Get your extension signed
 
-Once your extension is coded and tested, it needs to meet the policies in the [developer agreement](/documentation/publish/firefox-add-on-distribution-agreement/) and [add-on policies](/documentation/publish/add-on-policies/) before it is signed. If your extension doesn’t meet these policies, it may not get a signature or it could be [blocked](/documentation/publish/add-ons-blocking-process/) after signing.
+Extensions and themes need to be [submitted for signing](/documentation/publish/signing-and-distribution-overview/) by Mozilla before they can be installed in release and beta versions of Firefox for use in the [release](https://www.mozilla.org/firefox/) and [Beta](https://www.mozilla.org/firefox/channel/desktop/) versions of Firefox. Signing provides Firefox users with the assurance that an extension hasn’t been tampered with and gives Mozilla the ability to block malicious extensions. 
 
-When you’re confident your extension complies with those policies, it needs to be signed before it’s distributed\* for use in the [release](https://www.mozilla.org/firefox/) and [Beta](https://www.mozilla.org/firefox/channel/desktop/) versions of Firefox. Signing provides Firefox users with the assurance that an extension hasn’t been tampered with and gives Mozilla the ability to block malicious extensions.
+After you have coded and tested your add-on, take a few minutes to see that it needs to meet the policies in the [Firefox Add-on Distribution Agreement](/documentation/publish/firefox-add-on-distribution-agreement/) and [Add-on Policies](/documentation/publish/add-on-policies/). If your extension does not comply with these policies, it may not get a signature or it could be [blocked](/documentation/publish/add-ons-blocking-process/) after signing.
 
-All extensions can be submitted for signing through [addons.mozilla.org](https://addons.mozilla.org).
+When you are ready to submit your add-on, create an extension package either [manually](/documentation/publish/package-your-extension/) or using [web-ext](/documentation/develop/getting-started-with-web-ext/).
 
-Before submitting your extension for signing, create an extension package either [manually](/documentation/publish/package-your-extension/) or using [web-ext](/documentation/develop/getting-started-with-web-ext/). Once you’ve packaged your extension, there are [three ways to get it signed](/documentation/publish/signing-and-distribution-overview/).
-
-Once your extension is signed, it is subject to review by Mozilla at any time. To enable this review, you may have to [submit the source code](/documentation/publish/source-code-submission/) for your extension.
+Once your extension is submitted, it is subject to review by Mozilla at any time. In order to review your extension, Mozilla add-on reviewers must be able to reproduce your build. If your extension makes use of code minifiers, tools that generate a single file from other files, template engines, or any other custom tool that pre-processes and generates file(s) to include in your extension, you are required to [submit the source code](/documentation/publish/source-code-submission/) for your extension.
 
 {% endcapture %}
 {% include modules/column-w-toc.liquid
@@ -86,7 +84,7 @@ Check out our [publisher’s resources](/documentation/manage/resources-for-publ
 
 ## Promote your extension
 
-Grow your user base by [creating an appealing listing](/documentation/develop/create-an-appealing-listing/) for your extension.
+Improve your add-on's SEO and attract more users by [creating an appealing listing](/documentation/develop/create-an-appealing-listing/) for your extension.
 
 <!-- Video Popup Thumbnail -->
 
@@ -99,14 +97,16 @@ Grow your user base by [creating an appealing listing](/documentation/develop/cr
 
 <!-- END: Video Popup Thumbnail -->
 
-However you choose to distribute your extension, you’ll want to [promote your extension](/documentation/publish/promoting-your-extension/).
+Regardless of how you plan to distribute your add-on, you will want to [promote your extension](/documentation/publish/promoting-your-extension/).
 
-Mozilla promotes a selection of [Recommended Extensions](https://blog.mozilla.org/addons/2019/04/08/recommended-extensions-program-coming-soon/) that meet a high standard of security, utility, and user experience. If you’d like your extension to be included in the program, submit a nomination.
+Mozilla promotes a selection of [Recommended Extensions](/documentation/publish/recommended-extensions/) that meet a high standard of security, utility, and user experience. If you’d like your extension to be included in the program, submit a nomination.
 
 [Making money from browser extensions](/documentation/publish/make-money-from-browser-extensions/) is also something you might want to consider as your user base grows.
 
 ::: note
-If you’re distributing to an enterprise running the ESR version of Firefox or to users of Developer Edition or Nightly you don’t need to submit your extension to addons.mozilla.org for signing, you can distribute and install unsigned extensions.
+If you’re distributing to an enterprise running the ESR version of Firefox, and the administrator of the enterprise has disabled signing enforcement, then those users can install unsigned extensions. This means you do not need to submit your extension to addons.mozilla.org for signing.
+
+Users of Developer Edition or Nightly can also disable Firefox's signing enforcement.
 :::
 
 {% endcapture %}

--- a/src/content/documentation/publish/self-distribution.md
+++ b/src/content/documentation/publish/self-distribution.md
@@ -4,9 +4,9 @@ title: Distributing an add-on yourself
 permalink: /documentation/publish/self-distribution/
 topic: Publish
 tags: [add-on, distribution, publication, reviews, signing, installation]
-contributors: [rebloor]
-last_updated_by: rebloor
-date: 2019-08-18 11:19:17
+contributors: [caitmuenster, rebloor]
+last_updated_by: caitmuenster
+date: 2021-09-14 
 ---
 
 <!-- Page Hero Banner -->
@@ -29,9 +29,8 @@ date: 2019-08-18 11:19:17
 You aren't required to list or distribute your add-on through [addons.mozilla.org](https://addons.mozilla.org) (AMO); you can distribute it yourself. However, before distributing your add-on yourself, here are some things you should consider:
 
 - AMO is a very popular distribution platform, with millions of monthly visitors and installations. It's integrated into the Firefox Add-ons Manager, allowing for easy installation of add-ons published on AMO.
-- When an add-on is listed on AMO, Firefox automatically updates installed copies when a new version is listed on AMO. To enable Firefox to automatically update self-distributed add-ons, the URL where Firefox can find updates needs to be included in the add-on manifest's [`update_url`](/documentation/manage/updating-your-extension/#enable-update) key.
 
-For self-distributed add-ons that don't have an update URL, Firefox checks AMO for updates and the add-on is updated to a listed version, if one is available.
+- When an add-on is listed on AMO, Firefox automatically updates installed copies when a new version is listed on AMO. To enable Firefox to automatically update self-distributed add-ons, you need to include the URL where Firefox can find updates in the add-on manifest's [update_url](https://developer.mozilla.org/docs/Mozilla/Add-ons/Updates) key. If the add-on does not have an update URL to check, Firefox will check AMO for a listed update. If a listed update with a higher version number is available, Firefox will distribute that version to users who have installed the self-distributed file.
 
 For more information on how to submit an add-on for distribution on AMO or self-distribution, see [Submitting an add-on](/documentation/publish/submitting-an-add-on/).
 

--- a/src/content/documentation/publish/signing-and-distribution-overview.md
+++ b/src/content/documentation/publish/signing-and-distribution-overview.md
@@ -6,6 +6,7 @@ topic: Publish
 tags: [add-on, distribution, publication, reviews, signing, installation]
 contributors:
   [
+    caitmuenster,
     Kaligule,
     chrisdavidmills,
     mdnwebdocs-bot,
@@ -35,8 +36,8 @@ contributors:
     tedmcox,
     iwanrezpect,
   ]
-last_updated_by: Kaligule
-date: 2020-08-18 20:10:00
+last_updated_by: caitmuenster
+date: 2021-09-13 20:10:00
 ---
 
 <!-- Page Hero Banner -->
@@ -62,21 +63,29 @@ Here we look at the signing requirements and the related reviews, before discuss
 
 ## Signing your add-ons
 
-Starting with Firefox 43, add-on extensions and multi-item add-ons that include extensions need to be signed by Mozilla before they can install in release and beta versions of Firefox. This includes themes and language packs; dictionaries don't need to be signed however.
+Extensions and themes need to be signed by Mozilla before they can be installed in release and beta versions of Firefox. Dictionaries don't need to be signed.
 
 Unsigned extensions can be installed in [Developer Edition](https://www.mozilla.org/firefox/developer/), [Nightly](https://www.mozilla.org/firefox/nightly/all/), and [ESR](https://www.mozilla.org/firefox/organizations/) versions of Firefox, after toggling the `xpinstall.signatures.required` preference in `about:config`.
 
-Mozilla signs add-ons through the [AMO](https://addons.mozilla.org) website and provides three methods for submitting your add-on for signing:
+Mozilla signs add-ons through [addons.mozilla.org](https://addons.mozilla.org). You can use one of the following methods to sign your extension, but please be aware that not all signing methods support all distribution options. 
 
-- upload your add-on through the [Developer Hub on AMO](/documentation/publish/submitting-an-add-on/#listing-on-amo).
-- use the [addons.mozilla.org signing API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html).
-- use [web-ext sign](/documentation/develop/web-ext-command-reference/#web-ext-sign).
+<!-- Table -->
 
-All the signing options are subject to the [Firefox Add-on Distribution Agreement](/documentation/publish/firefox-add-on-distribution-agreement/).
+{% capture table %}
 
-Using the signing API or web-ext returns you signed add-ons, with no distribution listing created on AMO. If you take the option to upload your add-on through the AMO Developer Hub, you're given a choice between listing on AMO or self-distribution. If you choose self-distribution, at the end of the process you download signed copies of your add-on.
+| Signing method     | Supported distribution channel(s) | 
+| ------------------------------------- | ------------------- | 
+| Web upload via the [AMO Developer Hub](https://addons.mozilla.org/developers/) | Public listing on AMO or self-distribution| 
+| Submit using [web-ext sign](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#web-ext-sign) or using the [AMO signing API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html) | Brand new submissions can only be submissted as self-distributed (unlisted) extensions. <br /><br /> Subsequent updates can be listed on AMO or self-distributed (unlisted)| 
 
-Regardless of the method used all add-ons must pass an automated validation before they are signed. They may also be subject to a manual code review. The review criteria applied to add-ons are found in the [Add-on Policies](/documentation/publish/add-on-policies/).
+{% endcapture %}
+{% include modules/table.liquid
+	content: table
+%}
+
+<!-- END: Table -->
+
+All submissions, regardless of how they are signed, are subject to Mozilla's [Add-on Policies](/documentation/publish/add-on-policies/) and the the [Firefox Add-on Distribution Agreement](/documentation/publish/firefox-add-on-distribution-agreement/).
 
 {% endcapture %}
 {% include modules/column-w-toc.liquid
@@ -91,15 +100,19 @@ Regardless of the method used all add-ons must pass an automated validation befo
 {% capture content %}
 
 ## Distributing your add-on
+You can choose to distribute your add-on publicly on addons.mozilla.org (AMO) or distribute an it yourself. Here are some things to consider when you are deciding which method is most appropriate for your needs. 
 
-You aren't required to list or distribute your add-on through AMO. You'll, therefore, need to decide if you want to distribute and list your add-on through AMO or distribute it yourself. Here are some things you should consider:
+### Public listing on addons.mozilla.org (AMO) 
+AMO is a very popular distribution platform, with millions of monthly visitors and installations. It's integrated into the Firefox Add-ons Manager, allowing for easy installation of add-ons published on AMO. You can boost your extension’s SEO and attract more users by [creating an appealing listing](/documentation/develop/create-an-appealing-listing/). 
 
-- AMO is a very popular distribution platform, with millions of monthly visitors and installations. It's integrated into the Firefox Add-ons Manager, allowing for easy installation of add-ons published on AMO.
-
-- When an add-on is listed on AMO, updates to installed copies are handled automatically by Firefox each time a new version is listed on AMO.
-  To enable Firefox to automatically update self-distributed add-ons, the URL where Firefox can find updates needs to be included in the add-on manifest's [update_link](https://developer.mozilla.org/docs/Mozilla/Add-ons/Updates) key. Self-distributed add-ons that don't have an update URL check AMO for updates and are updated to a listed version, if one is available.
+When an add-on is listed on AMO, updates to installed copies are handled automatically by Firefox each time a new version is listed on AMO.
 
 For more information on how to submit an add-on for distribution on AMO or self-distribution, see [Submitting an add-on](/documentation/publish/submitting-an-add-on/).
+
+### Self-distribution
+Self-distributed add-ons are sometimes referred to as “unlisted” extensions because they cannot be publicly viewed or installed from AMO. You may want to self-distribute your extension if it is a beta version or if it is intended to be used by a limited audience. All add-ons, including self-distributed ones, are subject to be manually reviewed at any time after submission to check for compliance with the [Add-on Policies](/documentation/publish/add-on-policies/).
+
+If you choose this method, be sure to read the article on [self-distribution](/documentation/publish/self-distribution/) to learn how users can install self-distributed add-ons and how to push automatic updates to your users. 
 
 {% endcapture %}
 {% include modules/one-column.liquid
@@ -114,7 +127,26 @@ For more information on how to submit an add-on for distribution on AMO or self-
 
 {% capture content %}
 
-## More information about AMO
+## Post-submission review
+Regardless of distribution method, all add-ons undergo automated validation before they are signed. It can take up to 24 hours for your submission to be signed and published, or longer if your submission is selected for manual review. 
+
+All add-ons are subject to a manual code review at any time after submission. The review criteria applied to add-ons are found in the [Add-on Policies](/documentation/publish/add-on-policies/). Reviews may result in the rejection of current or previous versions of your add-on, or in your add-on being blocked. 
+
+See [What does review rejection mean to users?](/documentation/publish/what-does-review-rejection-mean-to-users/) and [Add-ons Blocking Process](/documentation/publish/add-ons-blocking-process/) for more information.
+
+{% endcapture %}
+{% include modules/one-column.liquid
+  id: "post-submission-review"
+  content: content
+%}
+
+<!-- END: Single Column Body Module -->
+
+<!-- Single Column Body Module -->
+
+{% capture content %}
+
+## More information about addons.mozilla.org (AMO)
 
 <section id="ownership"></section>
 

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -841,6 +841,10 @@
                     "id": "distributing-your-addon"
                   },
                   {
+                    "title": "Post-submission review",
+                    "id": "post-submission-review"
+                  },
+                  {
                     "title": "More information about AMO",
                     "id": "about-amo"
                   }


### PR DESCRIPTION
This PR includes some changes to the Publish overview, signing and distribution overview, and self-distribution pages to more accurately describe the submission and post-review process. 