### PR TITLE
Remove empty subpageitems

### DIFF
--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -767,8 +767,7 @@
               },
               {
                 "title": "Firefox Add-on Distribution Agreement (December 2021)",
-                "url": "/documentation/publish/firefox-add-on-distribution-agreement-dec-2021/",
-                "subpageitems": []
+                "url": "/documentation/publish/firefox-add-on-distribution-agreement-dec-2021/"
               },
               {
                 "title": "Add-ons Blocking Process",
@@ -1389,7 +1388,7 @@
                    }
                 ]
               },
-              { 
+              {
                 "title": "Dynamic themes",
                 "url": "/documentation/themes/dynamic-themes/",
                 "subpageitems": [


### PR DESCRIPTION
Removing this stops an empty toc being created in the doc:

<img width="1504" alt="Firefox_Add-on_Distribution_Agreement__December_2021____Firefox_Extension_Workshop" src="https://user-images.githubusercontent.com/1514/143235572-708938a7-4e13-4847-b5fb-95a79d57f354.png">

