### PR TITLE
Install unsigned extensions clarification

### DIFF
--- a/src/content/documentation/develop/extensions-and-the-add-on-id.md
+++ b/src/content/documentation/develop/extensions-and-the-add-on-id.md
@@ -105,7 +105,7 @@ You can do the same thing if you are updating from an older add-on type, such as
 
 ## When do you need an add-on ID?
 
-- If you are loading the add-on from its XPI file, are not loading it temporarily using `about:debugging` and it is not signed.
+- If you want to install an unsigned add-on from its XPI file, rather than loading it temporarily using `about:debugging`.
 - If you want to have a value other than a randomly generated ID upon [getting your extension signed](/documentation/publish/#get-your-extension-signed) for the first time.
 - If you use [AMO's API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html) for uploading your add-on, rather than uploading it manually on its page, then you need to include the add-on's ID in the request.
 - Some WebExtension APIs use the add-on ID and expect it to be the same from one browser session to the next. If you use these APIs, then you must set the ID explicitly using the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key. This applies to the following APIs:

--- a/src/content/documentation/publish/signing-and-distribution-overview.md
+++ b/src/content/documentation/publish/signing-and-distribution-overview.md
@@ -67,7 +67,7 @@ Here we look at the signing requirements and the related reviews, before discuss
 
 Extensions and themes need to be signed by Mozilla before they can be installed in release and beta versions of Firefox. Dictionaries don't need to be signed.
 
-Unsigned extensions can be installed in [Developer Edition](https://www.mozilla.org/firefox/developer/), [Nightly](https://www.mozilla.org/firefox/nightly/all/), and [ESR](https://www.mozilla.org/firefox/organizations/) versions of Firefox, after toggling the `xpinstall.signatures.required` preference in `about:config`.
+Unsigned extensions can be installed in the [Developer Edition](https://www.mozilla.org/firefox/developer/), [Nightly](https://www.mozilla.org/firefox/nightly/all/), and [ESR](https://www.mozilla.org/firefox/organizations/) versions of Firefox, after toggling the `xpinstall.signatures.required` preference in `about:config`. To use this feature your extension must have an [add-on ID](/documentation/develop/extensions-and-the-add-on-id/).
 
 Mozilla signs add-ons through [addons.mozilla.org](https://addons.mozilla.org). You can use one of the following methods to sign your extension, but please be aware that not all signing methods support all distribution options. 
 


### PR DESCRIPTION
This address is the `dev-doc-needed` request on [Bug 1720923](https://bugzilla.mozilla.org/show_bug.cgi?id=1720923) Explicitly mention addon id is needed to install succssfully even in builds where "xpinstall.signatures.required" set to false is supported