### PR TITLE
remove dead links to webextensions.in

### DIFF
--- a/src/content/documentation/develop/browser-extension-development-tools.md
+++ b/src/content/documentation/develop/browser-extension-development-tools.md
@@ -60,7 +60,7 @@ Create a scaffold for your browser extensions. Provide the tool with extension n
 
 ![Extension Scaffolding Builder](/assets/img/documentation/develop/Extension_scaffolding_builder.png)
 
-To get started, [visit the tool online](https://webextensions.in/) or [install it locally from npm](https://www.npmjs.com/package/create-web-ext).
+To get started, [install the tool locally from npm](https://www.npmjs.com/package/create-web-ext).
 
 {% endcapture %}
 {% capture aside %}
@@ -71,7 +71,6 @@ To get started, [visit the tool online](https://webextensions.in/) or [install i
 
 ##### Resources
 
-- [create-web-ext online (webextensions.in)](https://webextensions.in/)
 - [create-web-ext on npm](https://www.npmjs.com/package/create-web-ext)
 - [GitHub project](https://github.com/web-ext-labs/create-web-ext)
 - [GitHub UI project](https://github.com/web-ext-labs/ui-tool)

--- a/src/content/documentation/develop/firefox-workflow-overview.md
+++ b/src/content/documentation/develop/firefox-workflow-overview.md
@@ -65,7 +65,7 @@ date: 2020-03-24 12:47:00
             <td></td>
         </tr>
         <tr>
-            <td><a href="https://webextensions.in/">Create your extension scaffold</a></td>
+            <td><a href="https://www.npmjs.com/package/create-web-ext">Create your extension scaffold</a></td>
             <td>Debug with the <a href="https://developer.mozilla.org/docs/Tools/Browser_Toolbox/">Add-on Debugging Window</a></td>
             <td><a href="/documentation/publish/source-code-submission/">Submit your source code</a> (if required)</td>
             <td><a href="/documentation/manage/updating-your-extension/">Update and improve your extension</a></td>


### PR DESCRIPTION
Closes #1323

The domain `webextensions.in` is now parked at a domain squatting service. It's probably a good idea to remove the links to it before it becomes more harmful. That's what this PR does. The [source repo for the old `webextensions.in`](https://github.com/web-ext-labs/ui-tool) hasn't seen a human commit in more than a year and a half. If they could be persuaded to remove the CNAME file from the ghpages branch and publish to a github.io address (with TLS enabled) that would be a better alternative still. But in the mean time the link to the parked domain is a risk.

#1323 has a link to someone's self-hosted version of the app but it's safest to use a site directly controlled by web-ext-labs or mozilla.

Related: https://github.com/web-ext-labs/ui-tool/issues/52