### PR TITLE
Add a note about `web-ext run --firefox-preview` in MV3 migration guide

### DIFF
--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -6,7 +6,7 @@ topic: Develop
 tags: [webextensions, api, firefox]
 contributors: [rebloor, willdurand]
 last_updated_by: willdurand
-date: 2022-05-17
+date: 2022-06-17
 ---
 
 <!-- Page Hero Banner -->
@@ -60,6 +60,10 @@ If you want to permanently install an MV3 extension, you need to use the Nightly
 %}
 
 {% capture content %}
+
+::: note
+Use [`web-ext run`](/documentation/develop/getting-started-with-web-ext/) with the `--firefox-preview` option to quickly try your MV3 extension.
+:::
 
 ## Developer preview changes
 


### PR DESCRIPTION
I thought we could give a bit more visibility to both web-ext and the new option on this page.