### PR TITLE
Correct chromium browsers

### DIFF
--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -4,9 +4,9 @@ title: Manifest V3 migration guide
 permalink: /documentation/develop/manifest-v3-migration-guide/
 topic: Develop
 tags: [webextensions, api, firefox]
-contributors: [rebloor, willdurand]
-last_updated_by: erosman
-date: 2022-08-11
+contributors: [rebloor, willdurand, yoasif]
+last_updated_by: yoasif
+date: 2022-08-26
 ---
 
 <!-- Page Hero Banner -->

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -30,7 +30,7 @@ We have introduced a developer preview of Manifest V3 to Firefox. This page prov
 
 Manifest v3 (MV3) is the umbrella term for a number of foundational changes to the WebExtensions API in Firefox. The name refers to the declared `manifest_version` key in each extension’s [manifest.json](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
 
-The Manifest v3 changes apply to extensions for Chromium-based browsers – such as Chrome, Edge, and Opera – Safari, and Firefox. While it is the goal to maintain a high degree of compatibility between the Firefox, Safari, and Chromium extension platforms, our implementation diverges where we think it matters and where our values point to a different direction.
+The Manifest v3 changes apply to extensions for Chromium-based browsers – such as Chrome, Edge, and Opera. While it is the goal to maintain a high degree of compatibility between the Firefox, Safari, and Chromium extension platforms, our implementation diverges where we think it matters and where our values point to a different direction.
 
 This article discusses the overall changes introduced with the developer preview of Manifest v3 for Firefox and also highlights where it diverges from the Chrome and Safari implementation.
 


### PR DESCRIPTION
>The Manifest v3 changes apply to extensions for Chromium-based browsers – such as Chrome, Edge, and Opera – Safari, and Firefox.

on the manifest 3 migration guide is ambiguous and confusing, as Safari and Firefox are not Chromium browsers. See https://www.reddit.com/r/firefox/comments/wxv4gs/manifest_v3_firefox_vs_chrome/iluvvs6/?context=3 for evidence of this confusion. 