### PR TITLE
Fix MDN manifest_version link in MV3 migration guide

### DIFF
--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -79,7 +79,7 @@ This section details the Manifest V3 changes made to Firefox and available in th
 
 ### Manifest version
 
-The manifest.json key [`manifest_version`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) accepts `3`. To use Manifest V3, update your manifest.json file like this:
+The manifest.json key [`manifest_version`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version) accepts `3`. To use Manifest V3, update your manifest.json file like this:
 
 ```json
 "manifest_version": 3


### PR DESCRIPTION
Currently this links to the page about the unrelated `version` field, rather than the `manifest_version` field.