### PR TITLE
Add link to MDN docs for how to prompt user to uninstall an extension

### DIFF
--- a/src/content/documentation/develop/best-practices-for-collecting-user-data-consents.md
+++ b/src/content/documentation/develop/best-practices-for-collecting-user-data-consents.md
@@ -133,7 +133,7 @@ In this example:
     - opts OUT of any feature that cannot be disabled &rarr; offer them the option to remove the extension. If they choose not to remove the extension present the consent dialog again.
     - opts OUT only from features that can be disabled &rarr; disable those features and continue running the extension.
 
-You can prompt the user to uninstall the extension with [`management.uninstallSelf()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/uninstallSelf)
+You can prompt the user to uninstall the extension with [`management.uninstallSelf()`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/management/uninstallSelf).
 
 {% endcapture %}
 {% include modules/one-column.liquid,

--- a/src/content/documentation/develop/best-practices-for-collecting-user-data-consents.md
+++ b/src/content/documentation/develop/best-practices-for-collecting-user-data-consents.md
@@ -5,9 +5,9 @@ permalink: /documentation/develop/best-practices-for-collecting-user-data-consen
 topic: Develop
 tags:
   [add-ons, extensions, how-to, privacy, ui, user-interface, ux, webextensions]
-contributors: [rebloor]
-last_updated_by: kewisch
-date: 2021-12-01
+contributors: [rebloor, hamatti]
+last_updated_by: hamatti
+date: 2023-01-11
 ---
 
 <!-- Page Hero Banner -->
@@ -132,6 +132,8 @@ In this example:
     - opts IN to all features &rarr; continue with all extension features enabled.
     - opts OUT of any feature that cannot be disabled &rarr; offer them the option to remove the extension. If they choose not to remove the extension present the consent dialog again.
     - opts OUT only from features that can be disabled &rarr; disable those features and continue running the extension.
+
+You can prompt the user to uninstall the extension with [`management.uninstallSelf()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management/uninstallSelf)
 
 {% endcapture %}
 {% include modules/one-column.liquid,


### PR DESCRIPTION
The Extension Workshop page tells that developers should request the user to uninstall the add-on if they don't consent/opt-in to all necessary policies and features but it doesn't tell how.

This change adds a link to the MDN page for documentation on how to do that so it's easier for developers to get to the right source right away.

This PR adds the last line of the below screenshot.

<img width="1002" alt="Screenshot of documentation for consent flow in extension" src="https://user-images.githubusercontent.com/1909996/211846167-95ff1897-7554-49c9-8628-7b2bd1210227.png">

Fixes #1515 