### PR TITLE
Update for general availability of MV3

### DIFF
--- a/src/content/documentation/develop/extensions-and-the-add-on-id.md
+++ b/src/content/documentation/develop/extensions-and-the-add-on-id.md
@@ -6,24 +6,25 @@ topic: Develop
 tags: [webextensions]
 contributors:
   [
-    Rob--W,
-    jsantell,
-    mdnwebdocs-bot,
-    charmander,
-    freaktechnik,
-    wbamberg,
-    serv-inc,
-    scheinercc,
-    mconca,
-    DamienCassou,
     andrewtruongmoz,
     andymckay-github,
+    charmander,
+    DamienCassou,
+    freaktechnik,
+    jsantell,
+    mconca,
+    mdnwebdocs-bot,
+    rebloor,
+    Rob--W,
+    scheinercc,
+    serv-inc,
     timdream,
     Timendum,
-    willdurand,
+    wbamberg,
+    willdurand
   ]
-last_updated_by: willdurand
-date: 2022-05-17
+last_updated_by: rebloor
+date: 2023-03-03
 ---
 
 <!-- Page Hero Banner -->
@@ -32,11 +33,11 @@ date: 2022-05-17
 
 # Extensions and the add-on ID
 
-Firefox add-ons contain a unique ID which is used to distinguish this add-on from any other Firefox add-on.
+Firefox add-ons contain a unique ID that is used to distinguish one add-on from any other Firefox add-on.
 
-This article describes how add-on IDs are handled for extensions that are built with WebExtensions APIs.
+Firefox uses an extension's unique ID inside Firefox and on the [addons.mozilla.org](https://addons.mozilla.org/) (AMO) website. For example, it's used by Firefox to check for updates to installed add-ons and to identify which objects (such as data stores) are controlled by the add-on.
 
-Firefox add-ons contain a unique identifier which is used both inside Firefox itself and on the [addons.mozilla.org](https://addons.mozilla.org/) (AMO) website. For example, it's used by Firefox to check for updates to installed add-ons and to identify which objects (such as data stores) are controlled by this add-on.
+This article describes how add-on IDs are handled for extensions built with WebExtensions APIs.
 
 {% endcapture %}
 {% include modules/page-hero.liquid,
@@ -44,6 +45,55 @@ Firefox add-ons contain a unique identifier which is used both inside Firefox it
 %}
 
 <!-- END: Page Hero Banner -->
+
+<!-- Single Column Body Module -->
+
+<section id="when-do-you-need-an-add-on-id" class="module">
+<article class="module-content grid-x grid-padding-x">
+<div class="cell small-12">
+
+## When do I need an add-on ID?
+
+All [Manifest V3 extensions](/documentation/develop/manifest-v3-migration-guide/) need an add-on ID in their manifest.json when submitted to AMO.
+
+For Manifest V2 extensions, you need to add an add-on ID when:
+
+- You want to install an unsigned add-on from its XPI file, rather than loading it temporarily using `about:debugging`.
+- You want a specific ID, rather than one randomly generated when [your extension is first signed](/documentation/publish/#get-your-extension-signed).
+- You use [AMO's API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html) for uploading your add-on, rather than uploading it manually on its page, you must include the add-on's ID in the request.
+- You use WebExtension APIs that use the add-on ID and expect it to be the same from one browser session to the next. If you use these APIs, you must explicitly set the ID using the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key. This applies to the following APIs:
+  - [`storage.managed`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/managed "A storage.StorageArea object that represents the managed storage area. Items in managed storage are set by the domain administrator or other native applications installed on user's computer, and are read-only for the extension. Trying to modify this storage area results in an error.")
+  - [`storage.sync`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync 'Represents the sync storage area. Items in sync storage are synced by the browser, and are available across all instances of that browser that the user is logged into (e.g. via Firefox sync, or a Google account), across different devices.')
+  - [`identity.getRedirectURL`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL 'Generates a URL that you can use as a redirect URL.')
+  - [Native messaging](https://developer.mozilla.org/Add-ons/WebExtensions/Native_messaging)
+  - [`pkcs11`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11 'The pkcs11 API enables an extension to enumerate PKCS #11 security modules and to make them accessible to the browser as sources of keys and certificates.')
+  - [`runtime.onMessageExternal`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal "This API can't be used in a content script.")
+  - [`runtime.onConnectExternal`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onConnectExternal 'Fired when an extension receives a connection request from a different extension.')
+- You use the [`dictionaries` key in manifest.json](https://developer.mozilla.org/Mozilla/Add-ons/WebExtensions/manifest.json/dictionaries).
+
+Otherwise, for Manifest V2 extensions, AMO adds an add-on ID during the signing process.
+
+</div>
+</article>
+</section>
+
+<!-- END: Single Column Body Module -->
+
+<!-- Single Column Body Module -->
+
+<section id="how-do-i-set-an-add-on-id" class="module">
+<article class="module-content grid-x grid-padding-x">
+<div class="cell small-12">
+
+## How do I set an add-on ID?
+
+See [`browser_specific_settings` in manifest.json](https://developer.mozilla.org/Add-ons/WebExtensions/manifest.json/browser_specific_settings) for the syntax of setting the extension ID.
+
+</div>
+</article>
+</section>
+
+<!-- END: Single Column Body Module -->
 
 <!-- Single Column Body Module -->
 
@@ -58,69 +108,30 @@ Firefox add-ons contain a unique identifier which is used both inside Firefox it
 
 ## Basic workflow with no add-on ID (Manifest V2)
 
-Extensions can explicitly set the add-on ID using the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in manifest.json. However, this key is usually optional for Manifest V2 extensions. If you don't set it, then you can usually develop, debug, publish, and update your extension without ever having to deal with an ID. One advantage of this is that Google Chrome does not recognize the `browser_specific_settings` key and will show a warning if you include it.
+An add-on ID is usually optional for Manifest V2 extensions. If you don't set it, you can generally develop, debug, publish, and update your extension without ever having to deal with an ID. One advantage of this is that Google Chrome does not recognize the `browser_specific_settings` key and shows a warning if you include it.
 
-Note, though, that some WebExtension APIs use the add-on ID and expect it to be the same from one browser session to the next. If you use these APIs in Firefox, then you must set the ID explicitly using the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key. See [When do you need an Add-on ID?](#when-do-you-need-an-add-on-id).
+However, there are some implications of not setting an add-on ID that are described in this section.
 
 ### Developing and debugging
 
-If your manifest.json does not contain an ID then the extension will be assigned a randomly-generated temporary ID when you [install it in Firefox](/documentation/develop/temporary-installation-in-firefox/) through `about:debugging`. If you then reload the extension using the "Reload" button, the same ID will be used. If you then restart Firefox and load the add-on again, it will get a new ID.
+If your manifest.json does not contain an ID, the extension is assigned a randomly-generated temporary ID when you [install it in Firefox](/documentation/develop/temporary-installation-in-firefox/) through `about:debugging`. If you then reload the extension using the "Reload" button, the same ID is used. If you restart Firefox and load the add-on again, it gets a new ID.
 
-If you turn the extension into an `.xpi` or `.zip` and install it through `about:addons`, it will not work. To have it work in this scenario, you will need to add in the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in `manifest.json`.
+If you turn the extension into an `.xpi` or `.zip` and install it through `about:addons`, it will not work. For it to work, you must add the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in `manifest.json`.
 
 ### Publishing
 
-Once you have finished developing the extension, you can [package it and submit it to AMO for review and signing](/documentation/publish/signing-and-distribution-overview/). If the packaged extension you upload does not contain an ID, AMO will generate one for you. It's only at this point that the add-on will be assigned a permanent ID, which will be embedded in the signed packaged extension.
+Once you have finished developing the extension, you can [package it and submit it to AMO for review and signing](/documentation/publish/signing-and-distribution-overview/). If the packaged extension you upload does not contain an ID, AMO generates one. It's only at this point that the add-on is assigned a permanent ID, which is embedded in the signed packaged extension.
 
 ### Updating
 
-Even after this point, though, you don't generally have to deal with the ID at all. You can continue to develop the add-on without an ID, and when you want to update, upload the new version by visiting the add-on's AMO page. Because you are uploading the add-on through that page, AMO knows that this is an update to this particular add-on, even though it doesn't contain an ID.
+After publication, you don't generally have to deal with the ID. You can continue to develop the add-on without an ID, and when you want to update, upload the new version by visiting the add-on's AMO page. Because you are uploading the add-on through that page, AMO knows that this is an update to the add-on, even though it doesn't contain an ID.
 
 ::: note
-It's essential with this workflow that you update the add-on _manually using its page on AMO_, otherwise AMO will not understand that the submission is an update to an existing add-on, and will treat the update as a brand-new add-on.
+With this workflow, you must update the add-on _manually using its page on AMO_. Otherwise, AMO does not understand that the submission is an update to an existing add-on and treats the update as a new add-on.
 :::
 
-## What happens with Manifest V3?
-
-All [Manifest V3 extensions](/documentation/develop/manifest-v3-migration-guide/) need an add-on ID in their manifest.json when submitted to AMO. Contrary to Manifest V2 extensions, AMO will not accept Manifest V3 extensions without an ID and it will not automatically embed this ID in the signed packaged extension.
-
 </div>
 </article>
 </section>
 
 <!-- END: Single Column Body Module -->
-
-<!-- Single Column Body Module -->
-
-<section id="when-do-you-need-an-add-on-id" class="module">
-<article class="module-content grid-x grid-padding-x">
-<div class="cell small-12">
-
-## When do you need an add-on ID?
-
-All [Manifest V3 extensions](/documentation/develop/manifest-v3-migration-guide/) need an add-on ID in their manifest.json when submitted to AMO.
-
-For Manifest V2 extensions, you need an add-on ID when:
-
-- If you want to install an unsigned add-on from its XPI file, rather than loading it temporarily using `about:debugging`.
-- If you want to have a value other than a randomly generated ID upon [getting your extension signed](/documentation/publish/#get-your-extension-signed) for the first time.
-- If you use [AMO's API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html) for uploading your add-on, rather than uploading it manually on its page, then you need to include the add-on's ID in the request.
-- Some WebExtension APIs use the add-on ID and expect it to be the same from one browser session to the next. If you use these APIs, then you must set the ID explicitly using the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key. This applies to the following APIs:
-  - [`storage.managed`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/managed "A storage.StorageArea object that represents the managed storage area. Items in managed storage are set by the domain administrator or other native applications installed on user's computer, and are read-only for the extension. Trying to modify this storage area results in an error.")
-  - [`storage.sync`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync 'Represents the sync storage area. Items in sync storage are synced by the browser, and are available across all instances of that browser that the user is logged into (e.g. via Firefox sync, or a Google account), across different devices.')
-  - [`identity.getRedirectURL`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity/getRedirectURL 'Generates a URL that you can use as a redirect URL.')
-  - [Native messaging](https://developer.mozilla.org/Add-ons/WebExtensions/Native_messaging)
-  - [`pkcs11`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pkcs11 'The pkcs11 API enables an extension to enumerate PKCS #11 security modules and to make them accessible to the browser as sources of keys and certificates.')
-  - [`runtime.onMessageExternal`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal "This API can't be used in a content script.")
-  - [`runtime.onConnectExternal`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onConnectExternal 'Fired when an extension receives a connection request from a different extension.')
-- Using the [`dictionaries` key in manifest.json](https://developer.mozilla.org/Mozilla/Add-ons/WebExtensions/manifest.json/dictionaries).
-
-See [`browser_specific_settings` in manifest.json](https://developer.mozilla.org/Add-ons/WebExtensions/manifest.json/browser_specific_settings) for the syntax of setting the extension ID.
-
-</div>
-</article>
-</section>
-
-<!-- END: Single Column Body Module -->
-
-

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -297,7 +297,7 @@ Move the extension’s CSP to the manifest.json key to `extension_pages`, like t
 
 ### Web Accessible Resources
 
-Web accessible resources are available only to the sites and extensions specified in the manifest. Manifest V3 supports `resources` and `matches`, but does not support the `extension_ids` and `use_dynamic_url` properties.
+Web accessible resources are available only to the sites and extensions specified in the manifest. In Manifest V3, Firefox supports the `extension_ids`, `matches`, and `resources` properties to specify the packaged resources you want to make available. Firefox does not support the `use_dynamic_url` property.
 
 To migrate your extension, rewrite the manifest.json key [‘web_accessible_resources’](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources)  to specify the sites and extensions that can access the resources.
 
@@ -311,7 +311,7 @@ To migrate your extension, rewrite the manifest.json key [‘web_accessible_reso
 
 ### Features already supported by Firefox
 
-As part of its Manifest V3 implementation Chromium introduces [promise](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview#promises) support to many methods with the goal of eventually supporting promises on all appropriate methods. This will provide for greater compatibility between Firefox and Chrome extensions, given that Firefox already supports promises when using the `browser.*` namespace.
+As part of its Manifest V3 implementation, Chromium introduces [promise](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview#promises) support to many methods with the goal of eventually supporting promises on all appropriate methods. This will provide for greater compatibility between Firefox and Chrome extensions, given that Firefox already supports promises when using the `browser.*` namespace.
 
 In Manifest v2, Firefox extensions support the use of the `chrome.*` namespace with APIs that provide asynchronous event handling using callbacks. In Manifest v3, Firefox supports promises for asynchronous events in the `chrome.*` namespace.
 

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -4,9 +4,14 @@ title: Manifest V3 migration guide
 permalink: /documentation/develop/manifest-v3-migration-guide/
 topic: Develop
 tags: [webextensions, api, firefox]
-contributors: [rebloor, willdurand, erosman, Klestofer]
-last_updated_by: willdurand
-date: 2022-10-25
+contributors: [
+  erosman,
+  Klestofer,
+  rebloor,
+  willdurand
+]
+last_updated_by: rebloor
+date: 2023-03-03
 ---
 
 <!-- Page Hero Banner -->
@@ -15,7 +20,7 @@ date: 2022-10-25
 
 # Manifest V3 migration guide
 
-We have introduced a developer preview of Manifest V3 to Firefox. This page provides you with details of what's changed and how you adapt your extensions to take advantage of this preview.
+Manifest V3 became generally available in Firefox 109 after being available as a developer preview from Firefox 101. This page details what's changed and how you adapt your extensions to take advantage of Manifest V3.
 
 {% endcapture %}
 {% include modules/page-hero.liquid,
@@ -28,11 +33,11 @@ We have introduced a developer preview of Manifest V3 to Firefox. This page prov
 
 ## What is Manifest V3?
 
-Manifest v3 (MV3) is the umbrella term for a number of foundational changes to the WebExtensions API in Firefox. The name refers to the declared `manifest_version` key in each extension’s [manifest.json](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
+Manifest v3 (MV3) is the umbrella term for several foundational changes to the WebExtensions API in Firefox. The name refers to the declared `manifest_version` key in each extension’s [manifest.json](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
 
-The Manifest v3 changes apply to extensions for Chromium-based browsers – such as Chrome, Edge, and Opera – Safari, and Firefox. While it is the goal to maintain a high degree of compatibility between the Firefox, Safari, and Chromium extension platforms, our implementation diverges where we think it matters and where our values point to a different direction.
+The Manifest v3 changes apply to extensions for Safari, Firefox, and Chromium-based browsers – such as Chrome, Edge, and Opera. While the goal is to maintain a high degree of compatibility between the Firefox, Safari, and Chromium extension platforms, our implementation diverges where we think it matters and where our values point to a different direction.
 
-This article discusses the overall changes introduced with the developer preview of Manifest v3 for Firefox and also highlights where it diverges from the Chrome and Safari implementation.
+This article discusses the changes introduced with Manifest v3 in Firefox and highlights where they diverge from the Chrome and Safari implementation.
 
 {% endcapture %}
 {% include modules/column-w-toc.liquid,
@@ -42,32 +47,9 @@ This article discusses the overall changes introduced with the developer preview
 
 {% capture content %}
 
-## Turn on the developer preview
+## Manifest V3 changes
 
-The developer preview of Manifest V3 is available in Firefox 101. However, to test your extensions you need to turn on the MV3 features. To do this, go to `about:config` and:
-
-- Set `extensions.manifestV3.enabled` to `true`.
-- Set `xpinstall.signatures.required` to `false`.
-
-You can now install MV3 extensions from `about:debugging`.
-
-If you want to permanently install an MV3 extension, you need to use the Nightly or Developer edition channels with `xpinstall.signatures.required` set to `false`.
-
-{% endcapture %}
-{% include modules/one-column.liquid,
-    id: "turn-on-the-developer-preview"
-    content: content
-%}
-
-{% capture content %}
-
-::: note
-Use [`web-ext run`](/documentation/develop/getting-started-with-web-ext/) with the `--firefox-preview` option to quickly try your MV3 extension.
-:::
-
-## Developer preview changes
-
-This section details the Manifest V3 changes made to Firefox and available in the developer preview.
+This section details the Manifest V3 changes made to Firefox.
 
 {% endcapture %}
 {% include modules/one-column.liquid,
@@ -97,7 +79,7 @@ The manifest.json key [`manifest_version`](https://developer.mozilla.org/en-US/d
 
 Search extensions must use local icons. This change prevents the unnecessary network pings that result from accessing remote icons.
 
-To accommodate this change, provide a local icon and defined in your manifest.json [chrome_settings_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) manifest key like this:
+To accommodate this change, provide a local icon and define it in your manifest.json [chrome_settings_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) manifest key like this:
 
 ```json
 "chrome_settings_overrides": {
@@ -120,7 +102,7 @@ To accommodate this change, provide a local icon and defined in your manifest.js
 
 ### Host permissions
 
-Host permissions are no longer defined in the manifest.json keys `permissions` or `optional_permissions`, rather, they are defined in the [`host_permissions`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) key.
+Host permissions are no longer defined in the manifest.json keys `permissions` or `optional_permissions`. Instead, they are defined in the [`host_permissions`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) key.
 
 Move all host permission specifications to the manifest.json key `host_permissions` like this:
 
@@ -150,7 +132,7 @@ Move all host permission specifications to the manifest.json key `host_permissio
 
 The features available under the manifest.json key `browser_action` and the `browserAction` API have moved to a new `action` [key](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) and [API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/action). Also, the `_execute_action` [special shortcut](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#special_shortcuts) is introduced.
 
-As the old and new key and API are otherwise identical, the change is needed, are relatively straightforward, and are as follows:
+As the old and new key and API are otherwise identical, the changes needed are relatively straightforward and are as follows:
 
 - rename the manifest.json key 'browser_action' to 'action', like this:
   ```json
@@ -190,7 +172,7 @@ In Chromium and Safari, the Browser Action and Page Action APIs are unified into
 
 ### Scripting API
 
-The new [Scripting API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting) takes over the features of `tabs.insertCSS()`, `tabs.removeCSS()`,  and `tabs.executeScript()` and adds capabilities to register, update, and unregister content scripts at runtime.
+The [Scripting API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting) takes over the features of `tabs.insertCSS()`, `tabs.removeCSS()`,  and `tabs.executeScript()` and adds capabilities to register, update, and unregister content scripts at runtime.
 
 Also, the `code` parameter is removed so that arbitrary strings can no longer be executed. This API requires the [`scripting` permission](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). So, you need to move any arbitrary strings executed as scripts to files and rewrite your code to use the Scripting API.
 
@@ -204,9 +186,9 @@ Also, the `code` parameter is removed so that arbitrary strings can no longer be
 
 ### Event-driven background scripts
 
-Firefox has extended its support for [background scripts](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts) by enabling non-persistent background pages (aka Event Pages) for Manifest V2 and V3. Using non-persistent background scripts greatly reduces your extension use of browser resources. However, MV3 removes support for persistent background pages.
+Firefox has extended support for [background scripts](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts) by enabling non-persistent background pages (aka Event Pages) for Manifest V2 and V3. Using non-persistent background scripts greatly reduces your extension use of browser resources. However, MV3 removes support for persistent background pages.
 
-To migrate your extension to using non-persistent background pages you need to:
+To migrate your extension to using non-persistent background pages, you need to:
 
 - Update your manifest.json `background` key to remove the `"persistent"` property or set it to `false`. This feature is also supported in MV2 from Firefox 106.
 - Ensure listeners are at the top-level and use the synchronous pattern.
@@ -225,13 +207,13 @@ Firefox supports non-persistent background pages from Firefox 106. In Firefox 10
 
 More information on the migration process can be found on the [background script](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Background_scripts) page on MDN.
 
-#### Event pages and backwards-compatibility
+#### Event pages and backward-compatibility
 
 ::: note
 This section is only relevant if your extension supports Firefox 105 and earlier.
 :::
 
-An extension designed as a non-persistent background page works even when event pages are not supported (i.e. in Firefox 105 and earlier) 
+An extension designed as a non-persistent background page works even when event pages are not supported (i.e., in Firefox 105 and earlier) 
 with one exception: the registration of context menus. In an event page, context menus persist across restarts, while they do not in persistent background pages.
 If the recommendation to register menus in `runtime.onInstalled` is followed, these menus are removed after a browser restart in Firefox 105 and earlier.
 To work around this issue, you could unconditionally call `browser.contextMenus.create`.
@@ -252,9 +234,9 @@ browser.contextMenus.create(
 ```
 
 If the initialization of the menu is expensive or requires complex logic,
-an alternative is to check whether event pages are supported, and if so,
+an alternative is to check whether event pages are supported and, if so,
 run the logic less frequently than at every wakeup of the event page
-(e.g. with
+(e.g., with
 [`runtime.onInstalled`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled) or
 [`runtime.onStartup`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onStartup)
 ).
@@ -263,7 +245,7 @@ You can detect the availability of event pages using the characteristic that an
 error is thrown synchronously when `onclick` is passed to `contextMenus.create`
 in an event page.
 
-The following code shows how you can use such a test to register menus.
+The following code shows how to use such a test to register menus.
 
 ```javascript
 let eventPagesSupported = true;
@@ -297,7 +279,7 @@ if (eventPagesSupported) {
 
 [Content security policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) in the manifest.json key is changing to use the `extension_pages` property. Manifest V3 has a more restrictive content security policy than Manifest V2, this may require further changes in your pages.
 
-Move the extension’s CSP to the the manifest.json key to `extension_pages`, like this:
+Move the extension’s CSP to the manifest.json key to `extension_pages`, like this:
 
 ```json
 "content_security_policy": {
@@ -315,7 +297,7 @@ Move the extension’s CSP to the the manifest.json key to `extension_pages`, li
 
 ### Web Accessible Resources
 
-Web accessible resources are available only to the sites and extensions specified in the manifest. The developer preview supports `resources` and `matches`, but does not support the `extension_ids` and `use_dynamic_url` properties.
+Web accessible resources are available only to the sites and extensions specified in the manifest. Manifest V3 supports `resources` and `matches`, but does not support the `extension_ids` and `use_dynamic_url` properties.
 
 To migrate your extension, rewrite the manifest.json key [‘web_accessible_resources’](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources)  to specify the sites and extensions that can access the resources.
 
@@ -329,9 +311,9 @@ To migrate your extension, rewrite the manifest.json key [‘web_accessible_reso
 
 ### Features already supported by Firefox
 
-Chromium introduces [promise](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview#promises) support to many methods with the goal of eventually supporting promises on all appropriate methods. This will provide for greater compatibility between Firefox and Chrome extensions, given that Firefox already supports promises when using the `browser.*` namespace.
+As part of its Manifest V3 implementation Chromium introduces [promise](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview#promises) support to many methods with the goal of eventually supporting promises on all appropriate methods. This will provide for greater compatibility between Firefox and Chrome extensions, given that Firefox already supports promises when using the `browser.*` namespace.
 
-In Manifest v2, Firefox extensions support the use of the `chrome.*` namespace with APIs that provide asynchronous event handling using callbacks. In full release of Manifest v3, Firefox will support promises for asynchronous events in the `chrome.*` namespace.
+In Manifest v2, Firefox extensions support the use of the `chrome.*` namespace with APIs that provide asynchronous event handling using callbacks. In Manifest v3, Firefox supports promises for asynchronous events in the `chrome.*` namespace.
 
 {% endcapture %}
 {% include modules/one-column.liquid,
@@ -343,7 +325,7 @@ In Manifest v2, Firefox extensions support the use of the `chrome.*` namespace w
 
 ### Extension version in the manifest
 
-The format of the top-level manifest.json `version` key in Firefox has evolved and became simpler: letters and other previously allowed symbols are no longer accepted. The value must be a string with 1 to 4 numbers separated with dots (e.g. `1.2.3.4`). Each number can have up to 9 digits and leading zeros before another digit are not allowed (e.g. `2.01` is forbidden but `0.2`, `2.0.1` and `2.1` are allowed).
+The format of the top-level manifest.json `version` key in Firefox has evolved and became simpler: letters and other previously allowed symbols are no longer accepted. The value must be a string with 1 to 4 numbers separated by dots (e.g., `1.2.3.4`). Each number can have up to 9 digits and leading zeros before another digit are not allowed (e.g., `2.01` is forbidden, but `0.2`, `2.0.1`, and `2.1` are allowed).
 
 ## Migration checklist
 
@@ -352,11 +334,11 @@ The format of the top-level manifest.json `version` key in Firefox has evolved a
 - Remove any host permissions from the manifest.json keys `permissions` and `optional_permissions` and add them to the `host_permissions` key.
 - Rename the manifest.json key `browser_action` to `action` and update any API references from `browser.browserAction` to `browser.action`.
 - Convert background pages to be non-persistent.
-- Move the extension’s CSP to the the manifest.json key `content_security_policy.extension_pages` and update the CSP to conform to Manifest V3 requirements.
+- Move the extension’s CSP to the manifest.json key `content_security_policy.extension_pages` and update the CSP to conform to Manifest V3 requirements.
 - Move any arbitrary strings executed as scripts to files and update your code to use the Scripting API.
 - Rename the deprecated manifest.json key `applications` to `browser_specific_settings`.
 - The add-on ID is required to publish your extension. Make sure to add one in the manifest.json key `browser_specific_settings.gecko.id`.
-- Ensure that the top-level manifest.json key `version` is a string consisting of numbers separated with up to 3 dots. For details, see [version format](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version/format).
+- Ensure that the top-level manifest.json key `version` is a string of numbers separated by up to 3 dots. For details, see [version format](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version/format).
 
 {% endcapture %}
 {% include modules/one-column.liquid,
@@ -364,16 +346,5 @@ The format of the top-level manifest.json `version` key in Firefox has evolved a
     content: content
 %}
 
-{% capture content %}
-
-## Future features
-
-We are working towards a general availability release of manifest V3 for a future release.
-
-{% endcapture %}
-{% include modules/one-column.liquid,
-    id: "developer-preview-changes"
-    content: content
-%}
 <!-- END: Single Column Body Module -->
 

--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -6,33 +6,33 @@ topic: Develop
 tags: [commands, options, reference, tools, web-ext, webextensions]
 contributors:
   [
-    ankushduacodes,
-    lfilho,
-    rebloor,
-    mdnwebdocs-bot,
-    kumar303,
-    Rob--W,
-    smile4ever,
-    Dietrich,
-    andrewtruongmoz,
-    saintsebastian,
-    niharikak101,
-    wbamberg,
-    aniketkudale,
-    groovecoder,
-    tofumatt,
-    sharang,
-    chrisdavidmills,
-    noraj,
     akhilpanchal,
+    andrewtruongmoz,
+    aniketkudale,
     ankushduacodes,
-    willdurand,
+    ankushduacodes,
+    chrisdavidmills,
+    Dietrich,
     eviljeff,
+    groovecoder,
     hamatti,
-    LowerDimensions
+    kumar303,
+    lfilho,
+    LowerDimensions,
+    mdnwebdocs-bot,
+    niharikak101,
+    noraj,
+    rebloor,
+    Rob--W,
+    saintsebastian,
+    sharang,
+    smile4ever,
+    tofumatt,
+    wbamberg,
+    willdurand
   ]
-last_updated_by: hamatti
-date: 2022-11-18
+last_updated_by: rebloor
+date: 2023-03-03
 ---
 
 <!-- Page Hero Banner -->
@@ -162,9 +162,7 @@ Environment variable: `$WEB_EXT_WARNINGS_AS_ERRORS=true`
 
 #### `--firefox-preview`
 
-Turn on developer preview features in Firefox. This option accepts multiple values, although it currently only supports the `mv3` value, which is also the default value.
-
-The `mv3` value allows developers to lint Manifest Version 2 **and** Manifest Version 3 extensions.
+Turn on developer preview features in Firefox. This option accepts multiple values, depending on the available developer previews.
 
 ::: note
 This option was added in web-ext 7.3.0.
@@ -331,9 +329,7 @@ Environment variable: `$WEB_EXT_FIREFOX_APK`
 
 #### `--firefox-preview`
 
-Turn on developer preview features in Firefox. This option accepts multiple values, although it currently only supports the `mv3` value, which is also the default value.
-
-The `mv3` value allows developers to test their extensions with Firefox Manifest Version 3 support (without having to [manually flipping the related preferences](/documentation/develop/manifest-v3-migration-guide/)).
+Turn on developer preview features in Firefox. This option accepts multiple values, depending on the available developer previews.
 
 ::: note
 This option was added in web-ext 7.1.0.

--- a/src/content/documentation/publish/distribute-manifest-versions.md
+++ b/src/content/documentation/publish/distribute-manifest-versions.md
@@ -6,7 +6,7 @@ topic: Publish
 tags: [add-ons, beginner, tutorial, webextensions]
 contributors: [rebloor]
 last_updated_by: rebloor
-date: 2022-11-16
+date: 2023-03-03
 ---
 
 <!-- Page Hero Banner -->
@@ -26,17 +26,13 @@ Learn how to distribute versions of your extension supporting Manifest V2 and V3
 
 {% capture content_with_toc %}
 
-Firefox is adding support for Manifest Version 3 (MV3) extensions in Firefox 109, which releases to general availability January 17, 2023. However, earlier versions of Firefox are only compatible with Manifest Version 2 (MV2) extensions. And, it is not possible to create a version of an extension that is MV2 and MV3 compatible.
+Firefox added support for Manifest Version 3 (MV3) extensions in Firefox 109, which was released to general availability January 17, 2023. Earlier versions of Firefox are only compatible with Manifest Version 2 (MV2) extensions.
+
+It is not possible to create a version of an extension that is MV2- and MV3-compatible. Therefore, you need a way of distributing both types of extension if you need to continue supporting older clients, such as Firefox ESR. (Firefox ESR 102.x, the extended support release for enterprises – large companies and organizations – is supported until September 2023, when the ESR release moves to a version supporting MV3).
 
 To help address the situation, AMO can distribute your MV2-compatible extension and sign an MV3-compatible version for [self-distribution](/documentation/publish/self-distribution/). Some developers use this as a form of a beta channel, though it is not officially supported as such. 
 
-When deciding which version is most appropriate to distribute to your users through AMO, consider that:
-* When Firefox 109 becomes available, it may take several weeks for most users to update from a version of the browser that only supports MV2. 
-* Older clients, such as Firefox ESR – the extended support release for enterprises (large companies and organizations) – will remain in use for several months (Firefox ESR 102.x is supported until September 2023, when the ESR release will move to a version supporting MV3).
-
-So, if your user base is large, or you have requirements to provide support for older Firefox versions for an extended period, we recommend you consider using this alternate distribution for your MV3 version.
-
-If you choose to remain on MV2 and wait to transition to MV3 later, you can take steps in MV2 that [move your extension closer to what is necessary for MV3](https://blog.mozilla.org/addons/2022/10/31/begin-your-mv3-migration-by-implementing-new-features-today/). As usual, if your extension depends on features only available to recent Firefox versions, specify the compatible Firefox version in the [`strict_min_version`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) field in manifest.json. Older Firefox extensions will not receive an update. A new user on an old Firefox version can install an older version of the extension using the “See all versions” link at the extension listing on AMO.
+However, if you choose to remain on MV2 and wait to transition to MV3 later, you can take steps in MV2 that [move your extension closer to what is necessary for MV3](https://blog.mozilla.org/addons/2022/10/31/begin-your-mv3-migration-by-implementing-new-features-today/). As usual, if your extension depends on features only available to recent Firefox versions, specify the compatible Firefox version in the [`strict_min_version`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) field in manifest.json. Then, older Firefox extensions are not updated. A new user on an old Firefox version can install an older version of the extension using the “See all versions” link at the extension listing on AMO.
 
 {% endcapture %}
 {% include modules/column-w-toc.liquid,
@@ -51,7 +47,7 @@ If you choose to remain on MV2 and wait to transition to MV3 later, you can take
 
 ## Prepare your MV3 version
 
-To support automatic updates to newer MV3 versions, you need to create and make an update manifest file available and include the file’s location in the extension’s manifest file.
+To support automatic updates to newer MV3 versions, you must create and make an update manifest file available and include the file’s location in the extension’s manifest file.
 
 See [Updating your extension](/documentation/manage/updating-your-extension/) for details about the update manifest file format and manifest change needed.
 
@@ -72,7 +68,7 @@ To get a signed version of your MV3 extension:
 
 1. On AMO, when you upload the MV3 extension version, change “Where to host version”  to “on your own”.
    ::: note
-   You need to change it back to “on this site” for MV2 versions, as the most recently used channel is remembered.
+   You must change it back to “on this site” for MV2 versions, as the most recently used channel is remembered.
    :::
 2. For API uploads, specify `channel=unlisted` for the self-distribution channel.
 
@@ -108,10 +104,10 @@ See [Distributing an add-on yourself](/documentation/publish/self-distribution/)
 
 ## Transition your experimental MV3 version to your live version
 
-When you want to support just MV3-compatible versions of Firefox for your extension, visit AMO and upload the MV3 version to the primary AMO listed channel (“on this site”), without the `update_url` in the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) manifest key. Then, when signed, download the XPI and distribute it to your users as you did originally. The lack of the `update_url` manifest key means users will get updates from the AMO channel in the future.
+When you want to support just MV3-compatible versions of Firefox for your extension, visit AMO and upload the MV3 version to the primary AMO listed channel (“on this site”), without the `update_url` in the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) manifest key. Then, when signed, download the XPI and distribute it to your users as you did originally. The lack of the `update_url` manifest key means users get future updates from the AMO channel.
 
 ::: note
-Take care with version numbers. The version number needs to be higher than the earlier listed MV2 and experimental MV3 versions. Firefox only upgrades the extension if the version number is greater than the installed version.
+Take care with version numbers. The version number must be higher than the earlier listed MV2 and experimental MV3 versions. Firefox only upgrades the extension if the version number is greater than the installed version.
 :::
 
 {% endcapture %}


### PR DESCRIPTION
Updates various pages to remove references to the MV3 developer preview and noted it was released in Firefox 109. Also, undertook a general edit of the updated pages, except for the web-ext command reference page.