### PR TITLE
fix links to amo signing api docs

### DIFF
--- a/src/content/documentation/develop/extensions-and-the-add-on-id.md
+++ b/src/content/documentation/develop/extensions-and-the-add-on-id.md
@@ -21,10 +21,11 @@ contributors:
     timdream,
     Timendum,
     wbamberg,
-    willdurand
+    willdurand,
+    djbrown
   ]
-last_updated_by: rebloor
-date: 2023-03-03
+last_updated_by: djbrown
+date: 2023-04-22
 ---
 
 <!-- Page Hero Banner -->
@@ -60,7 +61,7 @@ For Manifest V2 extensions, you need to add an add-on ID when:
 
 - You want to install an unsigned add-on from its XPI file, rather than loading it temporarily using `about:debugging`.
 - You want a specific ID, rather than one randomly generated when [your extension is first signed](/documentation/publish/#get-your-extension-signed).
-- You use [AMO's API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html) for uploading your add-on, rather than uploading it manually on its page, you must include the add-on's ID in the request.
+- You use [AMO's API](https://addons-server.readthedocs.io/en/latest/topics/api/v4_frozen/signing.html) for uploading your add-on, rather than uploading it manually on its page, you must include the add-on's ID in the request.
 - You use WebExtension APIs that use the add-on ID and expect it to be the same from one browser session to the next. If you use these APIs, you must explicitly set the ID using the [`browser_specific_settings`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key. This applies to the following APIs:
   - [`storage.managed`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/managed "A storage.StorageArea object that represents the managed storage area. Items in managed storage are set by the domain administrator or other native applications installed on user's computer, and are read-only for the extension. Trying to modify this storage area results in an error.")
   - [`storage.sync`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync 'Represents the sync storage area. Items in sync storage are synced by the browser, and are available across all instances of that browser that the user is logged into (e.g. via Firefox sync, or a Google account), across different devices.')

--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -29,10 +29,11 @@ contributors:
     smile4ever,
     tofumatt,
     wbamberg,
-    willdurand
+    willdurand,
+    djbrown
   ]
-last_updated_by: rebloor
-date: 2023-03-03
+last_updated_by: djbrown
+date: 2023-04-22
 ---
 
 <!-- Page Hero Banner -->
@@ -502,7 +503,7 @@ This option is useful to prevent issues when the number of watched files is high
 
 ### `web-ext sign`
 
-This command uses the [addons.mozilla.org API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html) to sign your extension. If successful, it will download the signed `.xpi` file, which you can use to [self-host your extension](/documentation/publish/self-distribution/).
+This command uses the [addons.mozilla.org API](https://addons-server.readthedocs.io/en/latest/topics/api/v4_frozen/signing.html) to sign your extension. If successful, it will download the signed `.xpi` file, which you can use to [self-host your extension](/documentation/publish/self-distribution/).
 
 You need to create [API access credentials](http://addons-server.readthedocs.org/en/latest/topics/api/auth.html#access-credentials) to run this command. [Obtain your personal access credentials here](https://addons.mozilla.org/developers/addon/api/key/).
 
@@ -510,7 +511,7 @@ You need to create [API access credentials](http://addons-server.readthedocs.org
 
 #### `--use-submission-api`
 
-Use the experimental [addons.mozilla.org add-on submission API](https://addons-server.readthedocs.io/en/latest/topics/api/addons.html), rather than the [addons.mozilla.org signing API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html) to sign your extension. This allows listed versions to be freely created by enabling all necessary additional metadata to be submitted at the same time as the extension file.
+Use the experimental [addons.mozilla.org add-on submission API](https://addons-server.readthedocs.io/en/latest/topics/api/addons.html), rather than the [addons.mozilla.org signing API](https://addons-server.readthedocs.io/en/latest/topics/api/v4_frozen/signing.html) to sign your extension. This allows listed versions to be freely created by enabling all necessary additional metadata to be submitted at the same time as the extension file.
 
 With this option enabled, `--channel` changes to be a required option with no default.  The choices remain `listed` and `unlisted`.
 
@@ -601,7 +602,7 @@ Setting `--channel=listed` for a new extension is not yet supported. See [https:
 Setting `--channel=listed` for a new version of a listed extension is not well supported. It will upload your new version to [addons.mozilla.org](https://addons.mozilla.org) as if you'd [submitted it manually](/documentation/publish/submitting-an-add-on/). However, the command will fail and you'll have to check [addons.mozilla.org/developers/addons](https://addons.mozilla.org/developers/addons) for the correct status.
 :::
 
-See [documentation on the signing API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html#uploading-a-version) for more information.
+See [documentation on the signing API](https://addons-server.readthedocs.io/en/latest/topics/api/v4_frozen/signing.html#uploading-a-version) for more information.
 
 Environment variable: `$WEB_EXT_CHANNEL`
 </section>

--- a/src/content/documentation/publish/signing-and-distribution-overview.md
+++ b/src/content/documentation/publish/signing-and-distribution-overview.md
@@ -37,9 +37,10 @@ contributors:
     iwanrezpect,
     SolidAxel,
     jean-acsas,
+    djbrown
   ]
-last_updated_by: jean-acsas
-date: 2022-05-17 18:52:00
+last_updated_by: djbrown
+date: 2023-04-22
 ---
 
 <!-- Page Hero Banner -->
@@ -78,7 +79,7 @@ Mozilla signs add-ons through [addons.mozilla.org](https://addons.mozilla.org). 
 | Signing method     | Supported distribution channel(s) | 
 | ------------------------------------- | ------------------- | 
 | Web upload via the [AMO Developer Hub](https://addons.mozilla.org/developers/) | Public listing on AMO or self-distribution| 
-| Submit using [web-ext sign](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#web-ext-sign) or using the [AMO signing API](https://addons-server.readthedocs.io/en/latest/topics/api/signing.html) | Brand new submissions can only be submitted as self-distributed (unlisted) extensions. <br /><br /> Subsequent updates can be listed on AMO or self-distributed (unlisted)| 
+| Submit using [web-ext sign](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#web-ext-sign) or using the [AMO signing API](https://addons-server.readthedocs.io/en/latest/topics/api/v4_frozen/signing.html) | Brand new submissions can only be submitted as self-distributed (unlisted) extensions. <br /><br /> Subsequent updates can be listed on AMO or self-distributed (unlisted)| 
 
 {% endcapture %}
 {% include modules/table.liquid,


### PR DESCRIPTION
which was removed from v5
and is only available on v4 (frozen/stable)
see also https://github.com/mozilla/addons-server/issues/20560