### PR TITLE
Anatomy of an extension learn more links

### DIFF
--- a/src/includes/home/about.md
+++ b/src/includes/home/about.md
@@ -135,6 +135,8 @@ An extension is a simple collection of files that modify the browser’s appeara
 
 Add toolbar buttons, menu choices, and—only in Firefox—sidebars to display additional content. Manage tab behavior and create pop-up windows that respond to user events.
 
+[Learn more](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface)
+
 <button class="close"></button>
 
 </aside>
@@ -146,6 +148,8 @@ Add toolbar buttons, menu choices, and—only in Firefox—sidebars to display a
 
 Change webpage content. Remove ads, highlight key words, and reformat elements for readability.
 
+[Learn more](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)
+
 <button class="close"></button>
 
 </aside>
@@ -156,6 +160,8 @@ Change webpage content. Remove ads, highlight key words, and reformat elements f
 #### Background Scripts
 
 Manage long-term configuration beyond the current tab, and respond to user events such as button clicks and menu selections.
+
+[Learn more](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts)
 
 <button class="close"></button>
 

--- a/src/includes/home/about.md
+++ b/src/includes/home/about.md
@@ -148,7 +148,7 @@ Add toolbar buttons, menu choices, and—only in Firefox—sidebars to display a
 
 Change webpage content. Remove ads, highlight key words, and reformat elements for readability.
 
-[Learn more](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)
+[Learn more](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)
 
 <button class="close"></button>
 
@@ -161,7 +161,7 @@ Change webpage content. Remove ads, highlight key words, and reformat elements f
 
 Manage long-term configuration beyond the current tab, and respond to user events such as button clicks and menu selections.
 
-[Learn more](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts)
+[Learn more](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Background_scripts)
 
 <button class="close"></button>
 

--- a/src/includes/home/about.md
+++ b/src/includes/home/about.md
@@ -135,7 +135,7 @@ An extension is a simple collection of files that modify the browser’s appeara
 
 Add toolbar buttons, menu choices, and—only in Firefox—sidebars to display additional content. Manage tab behavior and create pop-up windows that respond to user events.
 
-[Learn more](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface)
+[Learn more](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface)
 
 <button class="close"></button>
 


### PR DESCRIPTION
Fixes #115 with additional learn more links in the user interface, content script, and background script popups i.e. 
<img width="1100" alt="image" src="https://github.com/mozilla/extension-workshop/assets/7352080/fdd2e657-5cb0-4ee5-a10a-ee4682739101">
