### PR TITLE
browser_style clarifications in MV3 guide

### DIFF
--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -128,30 +128,13 @@ Move all host permission specifications to the manifest.json key `host_permissio
 
 {% capture content %}
 
-### `browser_style`
-
-`browser_style: true` is no longer supported on the [options_ui](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui), [action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action), [page_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action), and [sidebar_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest keys in Manifest Version 3. When not explicitly set to `false`, `browser_style` used to default to `true` for `options_ui` and `sidebar_action` in Manifest Version 2.
-
-The goal of this property was to enable extension UI components to take on the browser's style. However, it only partially worked as intended. As a consequence, it has been deprecated for Manifest V3. Therefore, remove any references from the manifest keys, and confirm that the appearance of `options_ui` and `sidebar_action` matches your intended design, even if `"browser_style": true` was not explicitly specified.
-
-See [Manifest V3 migration for `browser_style`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration) for more information.
-
-{% endcapture %}
-{% include modules/one-column.liquid,
-    id: "browser-style"
-    content: content
-%}
-
-
-{% capture content %}
-
 ### Browser action
 
 The features available under the manifest.json key `browser_action` and the `browserAction` API have moved to a new `action` [key](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) and [API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/action). Also, the `_execute_action` [special shortcut](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#special_shortcuts) is introduced.
 
 As the old and new key and API are otherwise identical, the changes needed are relatively straightforward and are as follows:
 
-- rename the manifest.json key 'browser_action' to 'action', like this:
+- rename the manifest.json key 'browser_action' to 'action' and remove any reference to [`browser_style`](#browser-style), like this:
   ```json
   "action": {
     "default_icon": {
@@ -171,7 +154,6 @@ As the old and new key and API are otherwise identical, the changes needed are r
     }]
   }
   ```
-  Remember to remove any reference to `browser_style`.
 - update API references from `browser.browserAction` to  `browser.action`.
 - if used, change `_execute_browser_action` to `_execute_action` in the `commands` manifest key and in the [`menu.create`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/create) and [`menu.update`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/update) API methods (or their aliases `contextMenus.create` and `contextMenus.update`).
 
@@ -184,6 +166,25 @@ In Chromium and Safari, the Browser Action and Page Action APIs are unified into
     id: "browser-action"
     content: content
 %}
+
+{% capture content %}
+
+### `browser_style`
+
+In Manifest Version 3, `browser_style: true` is no longer supported in the [options_ui](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui), [action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action), [page_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action), and [sidebar_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest keys.
+
+The goal of this property was to enable extension UI components to take on the browser's style. However, it only partially worked as intended. As a consequence, it has been deprecated for Manifest V3. Therefore, remove any references from the manifest keys.  
+
+In Manifest Version 2, `browser_style` defaults to `true` for `options_ui` and `sidebar_action`. Therefore, unless you had set `"browser_style": false`, confirm that the appearance of `options_ui` and `sidebar_action` match your intended design.
+
+See [Manifest V3 migration for `browser_style`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration) for more information.
+
+{% endcapture %}
+{% include modules/one-column.liquid,
+    id: "browser-style"
+    content: content
+%}
+
 {% capture content %}
 
 ### Scripting API
@@ -349,7 +350,7 @@ The format of the top-level manifest.json `version` key in Firefox has evolved a
 - If your extension adds a search engine, add a local icon and reference it in the manifest.json key `chrome_settings_overrides.search_provider.favicon_url`.
 - Remove any host permissions from the manifest.json keys `permissions` and `optional_permissions` and add them to the `host_permissions` key.
 - Remove references to `browser_style` from the manifest.json keys `browser_action`, `options_ui`, `page_action`, and `sidebar_action`.
-- Confirm that the appearance of `options_ui` and `sidebar_action` has not changed, if `browser_style:false` was not explicitly specified before.
+- If `browser_style:false` was not specified in `options_ui` and `sidebar_action`, confirm that their appearance has not changed.
 - Rename the manifest.json key `browser_action` to `action` and update any API references from `browser.browserAction` to `browser.action`.
 - Convert background pages to be non-persistent.
 - Move the extension’s CSP to the manifest.json key `content_security_policy.extension_pages` and update the CSP to conform to Manifest V3 requirements.

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -128,6 +128,23 @@ Move all host permission specifications to the manifest.json key `host_permissio
 
 {% capture content %}
 
+### `browser_style`
+
+The [browser_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action), [options_ui](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui), [page_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action), and [sidebar_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest keys may include the `browser_style` property.
+
+The goal of this property was to enable extension UI components to take on the browser's style. However, it only partially worked as intended. As a consequence, it has been deprecated for Manifest V3. Therefore, remove any references from the manifest keys. 
+
+See [Manifest V3 migration for `browser_style`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration) for more information.
+
+{% endcapture %}
+{% include modules/one-column.liquid,
+    id: "browser-style"
+    content: content
+%}
+
+
+{% capture content %}
+
 ### Browser action
 
 The features available under the manifest.json key `browser_action` and the `browserAction` API have moved to a new `action` [key](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) and [API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/action). Also, the `_execute_action` [special shortcut](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#special_shortcuts) is introduced.
@@ -137,7 +154,6 @@ As the old and new key and API are otherwise identical, the changes needed are r
 - rename the manifest.json key 'browser_action' to 'action', like this:
   ```json
   "action": {
-    "browser_style": true,
     "default_icon": {
       "16": "button/geo-16.png",
       "32": "button/geo-32.png"
@@ -155,6 +171,7 @@ As the old and new key and API are otherwise identical, the changes needed are r
     }]
   }
   ```
+  Remember to remove any reference to `browser_style`.
 - update API references from `browser.browserAction` to  `browser.action`.
 - if used, change `_execute_browser_action` to `_execute_action` in the `commands` manifest key and in the [`menu.create`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/create) and [`menu.update`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/update) API methods (or their aliases `contextMenus.create` and `contextMenus.update`).
 
@@ -167,7 +184,6 @@ In Chromium and Safari, the Browser Action and Page Action APIs are unified into
     id: "browser-action"
     content: content
 %}
-
 {% capture content %}
 
 ### Scripting API
@@ -332,6 +348,7 @@ The format of the top-level manifest.json `version` key in Firefox has evolved a
 - Update the manifest.json key `manifest_version` to `3`.
 - If your extension adds a search engine, add a local icon and reference it in the manifest.json key `chrome_settings_overrides.search_provider.favicon_url`.
 - Remove any host permissions from the manifest.json keys `permissions` and `optional_permissions` and add them to the `host_permissions` key.
+- Remove references to `browser_style` from the manifest.json keys `browser_action`, `options_ui`, `page_action`, and `sidebar_action`.
 - Rename the manifest.json key `browser_action` to `action` and update any API references from `browser.browserAction` to `browser.action`.
 - Convert background pages to be non-persistent.
 - Move the extension’s CSP to the manifest.json key `content_security_policy.extension_pages` and update the CSP to conform to Manifest V3 requirements.

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -130,9 +130,9 @@ Move all host permission specifications to the manifest.json key `host_permissio
 
 ### `browser_style`
 
-The [browser_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action), [options_ui](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui), [page_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action), and [sidebar_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest keys may include the `browser_style` property.
+`browser_style: true` is no longer supported on the [options_ui](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui), [action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action), [page_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action), and [sidebar_action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) manifest keys in Manifest Version 3. When not explicitly set to `false`, `browser_style` used to default to `true` for `options_ui` and `sidebar_action` in Manifest Version 2.
 
-The goal of this property was to enable extension UI components to take on the browser's style. However, it only partially worked as intended. As a consequence, it has been deprecated for Manifest V3. Therefore, remove any references from the manifest keys. 
+The goal of this property was to enable extension UI components to take on the browser's style. However, it only partially worked as intended. As a consequence, it has been deprecated for Manifest V3. Therefore, remove any references from the manifest keys, and confirm that the appearance of `options_ui` and `sidebar_action` matches your intended design, even if `"browser_style": true` was not explicitly specified.
 
 See [Manifest V3 migration for `browser_style`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles#manifest_v3_migration) for more information.
 
@@ -349,6 +349,7 @@ The format of the top-level manifest.json `version` key in Firefox has evolved a
 - If your extension adds a search engine, add a local icon and reference it in the manifest.json key `chrome_settings_overrides.search_provider.favicon_url`.
 - Remove any host permissions from the manifest.json keys `permissions` and `optional_permissions` and add them to the `host_permissions` key.
 - Remove references to `browser_style` from the manifest.json keys `browser_action`, `options_ui`, `page_action`, and `sidebar_action`.
+- Confirm that the appearance of `options_ui` and `sidebar_action` has not changed, if `browser_style:false` was not explicitly specified before.
 - Rename the manifest.json key `browser_action` to `action` and update any API references from `browser.browserAction` to `browser.action`.
 - Convert background pages to be non-persistent.
 - Move the extension’s CSP to the manifest.json key `content_security_policy.extension_pages` and update the CSP to conform to Manifest V3 requirements.


### PR DESCRIPTION
browser_style has been deprecated in Manifest V3. This change updates the manifest migration guide to recommend removal and to provide a link to further advice on MDN.