### PR TITLE
Update developing-extensions-for-firefox-for-android for aug 2023

### DIFF
--- a/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
+++ b/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
@@ -7,7 +7,7 @@ tags: [add-ons, beginner, guide, mobile, webextensions]
 contributors:
   [Rob--W, caitmuenster, rebloor, juraj, mdnwebdocs-bot, ExE-Boss, Ding-Fan, andrewtruongmoz]
 last_updated_by: Rob--W
-date: 2021-08-17
+date: 2023-08-29
 ---
 
 {% capture page_hero_banner_content %}
@@ -82,9 +82,6 @@ Then, on your development computer:
 {% capture content %}
 
 ## Check for Firefox for Android compatibility
-::: note alert
-Linting results are currently not updated to include Fenix compatibility. Some warnings may not be accurate.  
-:::
 
 Before running your extension on Firefox for Android, consider using [`web-ext lint`](/documentation/develop/web-ext-command-reference#web-ext-lint). Lint performs a check to determine if any of the permissions, manifest keys, and web extension APIs you’re using are incompatible with Firefox for Android. Lint relies on your extension’s manifest.json file including `strict_min_version`, it then reports on the features that are not supported by the minimum version you have set.
 
@@ -102,12 +99,15 @@ similar to this:
 Lint does not report on APIs that are not implemented by Firefox or Firefox for Android.
 :::
 
-When setting `strict_min_version`, unless you’re targeting a specific version of Firefox, choose the most recent version of Firefox you expect your extension to be compatible with. For example, you can reasonably expect that most installations of Firefox for Android will be the current or previous version. So, if the current version is 66, consider setting 65 is the minimum version.
+When setting `strict_min_version` in [`browser_specific_settings`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings), unless you’re targeting a specific version of Firefox, choose the most recent version of Firefox you expect your extension to be compatible with. Due to the different APIs and form factors on Android (compared to desktop Firefox), set `gecko_android` after explicitly verifying compatibility. This field enables a compatibility range that is distinct from Firefox for desktop.
 
 ```json
 "browser_specific_settings": {
   "gecko": {
-    "strict_min_version": "65.0"
+    "strict_min_version": "102.0"
+  },
+  "gecko_android": {
+    "strict_min_version": "113.0"
   }
 }
 ```
@@ -127,10 +127,10 @@ When setting `strict_min_version`, unless you’re targeting a specific version 
 ## Install and run your extension in Firefox for Android
 
 ::: note
-These instructions are for temporarily loading an extension. Instructions for persistent loading extensions in Firefox for Android Nightly can be found on [this blog post](https://blog.mozilla.org/addons/2020/09/29/expanded-extension-support-in-firefox-for-android-nightly/).
+These instructions are for temporarily loading an extension. Instructions for persistent loading of extensions in Firefox for Android Nightly or Beta can be found on [this blog post](https://blog.mozilla.org/addons/2020/09/29/expanded-extension-support-in-firefox-for-android-nightly/).
 :::
 
-In the unzipped directory of your extension, run `web-ext run -t firefox-android` and follow the instructions on screen to make sure you select the right device. Select `org.mozilla.fenix` as the apkname.
+In the unzipped directory of your extension, run `web-ext run -t firefox-android` and follow the instructions on screen to make sure you select the right device. Select `org.mozilla.fenix` as the apkname (or `org.mozilla.firefox_beta` for Firefox Beta for Android).
 
 Here is an example of the command:
 
@@ -164,11 +164,11 @@ web-ext run -t firefox-android --adb-device XXX --firefox-apk org.mozilla.fenix
 Currently, you cannot inspect the markup of Fenix's browserAction popups using the Firefox Developer Tools Inspector (see [bug 1637616](https://bugzilla.mozilla.org/show_bug.cgi?id=1637616)). As a workaround, we recommend that you temporarily change the extension to open the popup extension page into a tab to be able to inspect it.
 :::
 
-You can debug your extension in the web developer tools and view any `manifest.json` validation messages using `adb logcat`. To make use of these features, first set up Firefox remote debugging [over USB](https://developer.android.com/studio/debug/dev-options) or [Wi-Fi](https://developer.mozilla.org/docs/Tools/Remote_Debugging/Debugging_Firefox_for_Android_over_Wifi).
+You can debug your extension in the web developer tools and view any `manifest.json` validation messages using `adb logcat`. To make use of these features, first set up Firefox remote debugging [over USB](https://developer.android.com/studio/debug/dev-options).
 
 ### Using web development tools to debug your extension
 
-With your device connected over USB or Wi-Fi, open `about:debugging` and enable the device connection.
+With your device connected over USB, open `about:debugging` and enable the device connection.
 
 ![Enable USB Devices](/assets/img/documentation/develop/enable-device-connection.png)
 
@@ -200,7 +200,7 @@ For more details on using the web developer tools, see [Firefox Developer Tools]
 
 ### Viewing manifest validation messages using the console
 
-In addition to the console messages output through WebIDE, there may also be messages relating to the validation of the extension’s `manifest.json` files. These messages can be viewed using the adb logcat command. To avoid receiving other, unrelated messages, you can pipe the output through grep, filtering by the extension’s ID, for example:
+In addition to the console messages output through the Console, there may also be messages relating to the validation of the extension’s `manifest.json` files. These messages can be viewed using the adb logcat command. To avoid receiving other, unrelated messages, you can pipe the output through grep, filtering by the extension’s ID, for example:
 
 ```shell
 /path/to/adb logcat | grep borderify@example.com


### PR DESCRIPTION
- Remove outdated note about linter - now supported.
- Mention `gecko_android` and link browser_specific_settings MDN.
- Replace mention of WebIDE - does not exist any more.
- Remove mention of debugging over "Wi-Fi" - does not work any more.
- Mention that the collection feature works on Beta as well.