### PR TITLE
Create a "known issues" page

### DIFF
--- a/src/content/documentation/develop/known-issues.md
+++ b/src/content/documentation/develop/known-issues.md
@@ -33,17 +33,25 @@ This page contains a list of major known issues that affect experience of develo
 <!-- END: Page Hero Banner -->
 <!-- Single Column Body Module -->
 
-{% capture content %}
+{% capture content_with_toc %}
 
-### Issue: Content scripts not appearing in DevTools
+### Content scripts don't appear in DevTools
 
 **Description:** Content scripts sometimes won't appear in the sources list when debugging a tab on Android.
 
 **Workaround:** Add a `debugger` statement to your content script to manually trigger a breakpoint when the content script first executes.
 
-**Tracking issue:** [Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1746718)
+**Tracking issue:** [Bug 1746718](https://bugzilla.mozilla.org/show_bug.cgi?id=1746718)
 
-### Issue: Extension source do not update in DevTools
+{% endcapture %}
+{% include modules/column-w-toc.liquid,
+    id: "invisible-content-scripts"
+    content: content_with_toc
+%}
+
+{% capture content %}
+
+### Extension source don't update in DevTools
 
 **Description:** Sources files that have been opened in DevTools are not updated after you edit the file on disk. This issue applies to temporary extensions that have been installed in Firefox or that have been installed on an Android device using `web-ext`.
 
@@ -51,7 +59,15 @@ This page contains a list of major known issues that affect experience of develo
 
 **Tracking issue:** [Bug 1857368](https://bugzilla.mozilla.org/show_bug.cgi?id=1857368)
 
-### Issue: "Destroyed actor" errors when debugging Android
+{% endcapture %}
+{% include modules/one-column.liquid,
+    id: "devtools-updates-missing"
+    content: content
+%}
+
+{% capture content %}
+
+### "Destroyed actor" errors when debugging Android
 
 **Description:** While debugging an extension on Android, you may encounter an error in Firefox on your desktop that says something like:
 
@@ -65,7 +81,7 @@ Cannot connect to the debug target. See error details below:<br><br>
 
 **Workaround:** In the `about:debugging` page on your development computer, disconnect from and reconnect to the Android device.
 
-**Additional notes:** This issue appears to be related to having simultaneous connections to the Android device from `web-ext` and from Firefox's developer tools. To minimize the appearance of this issue, consider setting `web-ext` to only auto-reload select files `--watch-files`. For example:
+**Additional notes:** This issue appears to be related to having simultaneous connections to the Android device from `web-ext` and from Firefox's developer tools. To minimize the appearance of this issue, you can set `web-ext` to only auto-reload specific files by using the `--watch-files` flag. For example:
 
 ```bash
 web-ext run -t firefox-android \
@@ -74,9 +90,19 @@ web-ext run -t firefox-android \
   --watch-file manifest.json
 ```
 
+This approach also allows you to manually trigger a refresh by pressing `R` while the web-ext terminal window is focused.
+
 **Tracking issue:** [Bug 1856481](https://bugzilla.mozilla.org/show_bug.cgi?id=1856481)
 
-### Issue: Empty temporary extensions list when debugging Android
+{% endcapture %}
+{% include modules/one-column.liquid,
+    id: "android-destroyed-actor"
+    content: content
+%}
+
+{% capture content %}
+
+### Empty temporary extensions list when debugging Android
 
 **Description:** When debugging an extension on Android, the "`about:debugging`" page in Firefox on the development machine's may show an empty list of temporary extensions.
 
@@ -86,7 +112,7 @@ web-ext run -t firefox-android \
 
 {% endcapture %}
 {% include modules/one-column.liquid,
-  id: "known-issues"
+  id: "android-temp-ext-missing"
   content: content
 %}
 

--- a/src/content/documentation/develop/known-issues.md
+++ b/src/content/documentation/develop/known-issues.md
@@ -1,0 +1,93 @@
+---
+layout: sidebar
+title: Known issues
+permalink: /documentation/develop/known-issues/
+topic: Develop
+tags: [
+    android,
+    api,
+    debugging,
+    development,
+    firefox,
+    testing,
+    webextensions
+  ]
+contributors: [dotproto]
+last_updated_by: dotproto
+date: 2023-11-20
+---
+
+<!-- Page Hero Banner -->
+
+{% capture page_hero_banner_content %}
+
+# Known issues
+
+This page contains a list of major known issues that affect experience of developing extensions for Firefox and Firefox for Android.
+
+{% endcapture %}
+{% include modules/page-hero.liquid,
+    content: page_hero_banner_content
+%}
+
+<!-- END: Page Hero Banner -->
+<!-- Single Column Body Module -->
+
+{% capture content %}
+
+### Issue: Content scripts not appearing in DevTools
+
+**Description:** Content scripts sometimes won't appear in the sources list when debugging a tab on Android.
+
+**Workaround:** Add a `debugger` statement to your content script to manually trigger a breakpoint when the content script first executes.
+
+**Tracking issue:** [Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1746718)
+
+### Issue: Extension source do not update in DevTools
+
+**Description:** Sources files that have been opened in DevTools are not updated after you edit the file on disk. This issue applies to temporary extensions that have been installed in Firefox or that have been installed on an Android device using `web-ext`.
+
+**Workaround:** Close and re-open DevTools.
+
+**Tracking issue:** [Bug 1857368](https://bugzilla.mozilla.org/show_bug.cgi?id=1857368)
+
+### Issue: "Destroyed actor" errors when debugging Android
+
+**Description:** While debugging an extension on Android, you may encounter an error in Firefox on your desktop that says something like:
+
+<blockquote style="padding-left: 1rem; border-left: 5px solid #aaa;">
+
+Cannot connect to the debug target. See error details below:<br><br>
+
+`Error: Protocol error (Error): Attempted to write a response containing a destroyed actor from: root (resource://devtools/shared/protocol/types.js:358:17)`
+
+</blockquote>
+
+**Workaround:** In the `about:debugging` page on your development computer, disconnect from and reconnect to the Android device.
+
+**Additional notes:** This issue appears to be related to having simultaneous connections to the Android device from `web-ext` and from Firefox's developer tools. To minimize the appearance of this issue, consider setting `web-ext` to only auto-reload select files `--watch-files`. For example:
+
+```bash
+web-ext run -t firefox-android \
+  --android-device=emulator-5554 \
+  --firefox-apk=org.mozilla.fenix \
+  --watch-file manifest.json
+```
+
+**Tracking issue:** [Bug 1856481](https://bugzilla.mozilla.org/show_bug.cgi?id=1856481)
+
+### Issue: Empty temporary extensions list when debugging Android
+
+**Description:** When debugging an extension on Android, the "`about:debugging`" page in Firefox on the development machine's may show an empty list of temporary extensions.
+
+**Workaround:** Disconnect from and reconnect to the Android device on `about:debugging`.
+
+**Tracking issue:** [Bug 1856481](https://bugzilla.mozilla.org/show_bug.cgi?id=1856481)
+
+{% endcapture %}
+{% include modules/one-column.liquid,
+  id: "known-issues"
+  content: content
+%}
+
+<!-- END: Single Column Body Module -->

--- a/src/content/documentation/develop/known-issues.md
+++ b/src/content/documentation/develop/known-issues.md
@@ -24,7 +24,7 @@ date: 2023-11-20
 
 # Known issues
 
-This page contains a list of major known issues that affect experience of developing extensions for Firefox and Firefox for Android.
+This page contains a list of significant known issues that affect the experience of developing extensions for Firefox and Firefox for Android.
 
 {% endcapture %}
 {% include modules/page-hero.liquid,
@@ -38,7 +38,7 @@ This page contains a list of major known issues that affect experience of develo
 
 ### Content scripts don't appear in DevTools
 
-**Description:** Content scripts sometimes won't appear in the sources list when debugging a tab on Android.
+**Description:** Content scripts sometimes don't appear in the sources list when debugging a tab on Android.
 
 **Workaround:** Add a `debugger` statement to your content script to manually trigger a breakpoint when the content script first executes.
 
@@ -54,7 +54,7 @@ This page contains a list of major known issues that affect experience of develo
 
 ### Extension source don't update in DevTools
 
-**Description:** Sources files that have been opened in DevTools are not updated after you edit the file on disk. This issue applies to temporary extensions that have been installed in Firefox or that have been installed on an Android device using `web-ext`.
+**Description:** Sources files open in DevTools are not updated after you edit the file on disk. This issue applies to temporary extensions that are installed in Firefox or on an Android device using `web-ext`.
 
 **Workaround:** Close and re-open DevTools.
 

--- a/src/content/documentation/develop/known-issues.md
+++ b/src/content/documentation/develop/known-issues.md
@@ -10,6 +10,7 @@ tags: [
     development,
     firefox,
     testing,
+    web-ext,
     webextensions
   ]
 contributors: [dotproto]

--- a/src/content/documentation/develop/known-issues.md
+++ b/src/content/documentation/develop/known-issues.md
@@ -81,7 +81,7 @@ Cannot connect to the debug target. See error details below:<br><br>
 
 **Workaround:** In the `about:debugging` page on your development computer, disconnect from and reconnect to the Android device.
 
-**Additional notes:** This issue appears to be related to having simultaneous connections to the Android device from `web-ext` and from Firefox's developer tools. To minimize the appearance of this issue, you can set `web-ext` to only auto-reload specific files by using the `--watch-files` flag. For example:
+**Additional notes:** This issue appears to be related to simultaneous connections to the Android device from `web-ext` and Firefox's developer tools. To minimize the occurrence of this issue, set `web-ext` to auto-reload specific files only using the `--watch-files` flag. For example:
 
 ```bash
 web-ext run -t firefox-android \
@@ -104,7 +104,7 @@ This approach also allows you to manually trigger a refresh by pressing `R` whil
 
 ### Empty temporary extensions list when debugging Android
 
-**Description:** When debugging an extension on Android, the "`about:debugging`" page in Firefox on the development machine's may show an empty list of temporary extensions.
+**Description:** When debugging an extension on Android, the "`about:debugging`" page in Firefox on the development machine may show an empty list of temporary extensions.
 
 **Workaround:** Disconnect from and reconnect to the Android device on `about:debugging`.
 

--- a/src/content/documentation/develop/known-issues.md
+++ b/src/content/documentation/develop/known-issues.md
@@ -101,20 +101,4 @@ This approach also allows you to manually trigger a refresh by pressing `R` whil
     content: content
 %}
 
-{% capture content %}
-
-### Empty temporary extensions list when debugging Android
-
-**Description:** When debugging an extension on Android, the "`about:debugging`" page in Firefox on the development machine may show an empty list of temporary extensions.
-
-**Workaround:** Disconnect from and reconnect to the Android device on `about:debugging`.
-
-**Tracking issue:** [Bug 1856481](https://bugzilla.mozilla.org/show_bug.cgi?id=1856481)
-
-{% endcapture %}
-{% include modules/one-column.liquid,
-  id: "android-temp-ext-missing"
-  content: content
-%}
-
 <!-- END: Single Column Body Module -->

--- a/src/content/documentation/develop/known-issues.md
+++ b/src/content/documentation/develop/known-issues.md
@@ -54,7 +54,7 @@ This page contains a list of significant known issues that affect the experience
 
 ### Extension source don't update in DevTools
 
-**Description:** Sources files open in DevTools are not updated after you edit the file on disk. This issue applies to temporary extensions that are installed in Firefox or on an Android device using `web-ext`.
+**Description:** Sources files open in DevTools are not updated after you edit the file on disk. This issue applies to temporary extensions installed in Firefox or on an Android device using `web-ext`.
 
 **Workaround:** Close and re-open DevTools.
 
@@ -82,7 +82,7 @@ Cannot connect to the debug target. See error details below:<br><br>
 
 **Workaround:** In the `about:debugging` page on your development computer, disconnect from and reconnect to the Android device.
 
-**Additional notes:** This issue appears to be related to simultaneous connections to the Android device from `web-ext` and Firefox's developer tools. To minimize the occurrence of this issue, set `web-ext` to auto-reload specific files only using the `--watch-files` flag. For example:
+**Additional notes:** This issue appears to be related to simultaneous connections to the Android device from `web-ext` and Firefox's developer tools. To minimize the likelihood of this issue, set `web-ext` to auto-reload specific files only using the `--watch-files` flag. For example:
 
 ```bash
 web-ext run -t firefox-android \

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -31,7 +31,9 @@ See the [Developing extensions for Firefox for Android](/documentation/develop/d
 
 <!-- END: Page Hero Banner -->
 
-{% capture content %}
+<!-- Content with Table of Contents Module -->
+
+{% capture content_with_toc %}
 
 ## What is Manifest V3?
 
@@ -42,10 +44,15 @@ The Manifest V3 changes apply to extensions for Safari, Firefox, and Chromium-ba
 This article discusses the changes introduced with Manifest V3 in Firefox and highlights where they diverge from the Chrome and Safari implementation.
 
 {% endcapture %}
+
 {% include modules/column-w-toc.liquid,
     id: "what-is-manifest-v3"
-    content: content
+    content: content_with_toc
 %}
+
+<!-- END: Content with Table of Contents -->
+
+<!-- Single Column Body Module -->
 
 {% capture content %}
 
@@ -354,6 +361,14 @@ In Manifest v2, Firefox extensions support the use of the `chrome.*` namespace w
 
 The format of the top-level manifest.json `version` key in Firefox has evolved and became simpler: letters and other previously allowed symbols are no longer accepted. The value must be a string with 1 to 4 numbers separated by dots (e.g., `1.2.3.4`). Each number can have up to 9 digits and leading zeros before another digit are not allowed (e.g., `2.01` is forbidden, but `0.2`, `2.0.1`, and `2.1` are allowed).
 
+{% endcapture %}
+{% include modules/one-column.liquid,
+    id: "extension-version"
+    content: content
+%}
+
+{% capture content %}
+
 ## Migration checklist
 
 - Update the manifest.json key `manifest_version` to `3`.
@@ -371,9 +386,8 @@ The format of the top-level manifest.json `version` key in Firefox has evolved a
 
 {% endcapture %}
 {% include modules/one-column.liquid,
-    id: "developer-preview-changes"
+    id: "migration-checklist"
     content: content
 %}
 
 <!-- END: Single Column Body Module -->
-

--- a/src/content/documentation/develop/testing-persistent-and-restart-features.md
+++ b/src/content/documentation/develop/testing-persistent-and-restart-features.md
@@ -12,7 +12,6 @@ tags:
     how-to,
     intermediate,
     testing,
-    web-ext,
     webextensions,
   ]
 contributors: [freaktechnik, Rob--W, rebloor, tophf, Dietrich]

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -539,7 +539,25 @@
               },
               {
                 "title": "Known issues",
-                "url": "/documentation/develop/known-issues/"
+                "url": "/documentation/develop/known-issues/",
+                "subpageitems": [
+                  {
+                    "title": "Content scripts don't appear in DevTools",
+                    "id": "invisible-content-scripts"
+                  },
+                  {
+                    "title": "Extension source don't update in DevTools",
+                    "id": "devtools-updates-missing"
+                  },
+                  {
+                    "title": "\"Destroyed actor\" errors when debugging Android",
+                    "id": "android-destroyed-actor"
+                  },
+                  {
+                    "title": "Empty temporary extensions list when debugging Android",
+                    "id": "android-temp-ext-missing"
+                  }
+                ]
               }
             ]
           }

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -566,10 +566,6 @@
                   {
                     "title": "\"Destroyed actor\" errors when debugging Android",
                     "id": "android-destroyed-actor"
-                  },
-                  {
-                    "title": "Empty temporary extensions list when debugging Android",
-                    "id": "android-temp-ext-missing"
                   }
                 ]
               }

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -536,6 +536,10 @@
                     "id": "retest-runtime-permission-grants"
                   }
                 ]
+              },
+              {
+                "title": "Known issues",
+                "url": "/documentation/develop/known-issues/"
               }
             ]
           }

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -64,7 +64,21 @@
             "pages": [
               {
                 "title": "Manifest V3 migration guide",
-                "url": "/documentation/develop/manifest-v3-migration-guide/"
+                "url": "/documentation/develop/manifest-v3-migration-guide/",
+                "subpageitems": [
+                  {
+                    "title": "What is Manifest V3?",
+                    "id": "what-is-manifest-v3"
+                  },
+                  {
+                    "title": "Manifest V3 changes",
+                    "id": "developer-preview-changes"
+                  },
+                  {
+                    "title": "Migration checklist",
+                    "id": "migration-checklist"
+                  }
+                ]
               }
             ]
           },


### PR DESCRIPTION
This PR introduces a known issues page to highlight issues that may affect a developer's experience when trying to build Firefox extensions. The initial set of issues included on this page are taken from the set of known issues I included [in a talk I gave](https://assets.mozilla.net/pdf/2023-11-15-setup-testing-debugging.pdf) on November 15.

FYI: @willdurand, @rpl