### PR TITLE
Remove mdnwebdocs bot

### DIFF
--- a/src/content/documentation/develop/browser-extension-development-tools.md
+++ b/src/content/documentation/develop/browser-extension-development-tools.md
@@ -15,7 +15,7 @@ tags:
     translation,
     webextensions,
   ]
-contributors: [rebloor, mdnwebdocs-bot, hellosct1, ani-sha, ankushduacodes]
+contributors: [rebloor, hellosct1, ani-sha, ankushduacodes]
 last_updated_by: rebloor
 date: 2023-06-02
 ---

--- a/src/content/documentation/develop/browser-extension-development-tools.md
+++ b/src/content/documentation/develop/browser-extension-development-tools.md
@@ -15,7 +15,7 @@ tags:
     translation,
     webextensions,
   ]
-contributors: [rebloor, hellosct1, ani-sha, ankushduacodes]
+contributors: [rebloor, mdnwebdocs-bot, hellosct1, ani-sha, ankushduacodes]
 last_updated_by: rebloor
 date: 2023-06-02
 ---

--- a/src/content/documentation/develop/build-a-secure-extension.md
+++ b/src/content/documentation/develop/build-a-secure-extension.md
@@ -4,7 +4,7 @@ title: Build a secure extension
 permalink: /documentation/develop/build-a-secure-extension/
 topic: Develop
 tags: [beginner, extensions, intermediate, reviews, security, webextensions]
-contributors: [ caitmuenster, irenesmith, tomrittervg, rebloor]
+contributors: [ caitmuenster, irenesmith, tomrittervg, mdnwebdocs-bot, rebloor]
 last_updated_by: caitmuenster
 date: 2020-09-15
 ---

--- a/src/content/documentation/develop/build-a-secure-extension.md
+++ b/src/content/documentation/develop/build-a-secure-extension.md
@@ -4,7 +4,7 @@ title: Build a secure extension
 permalink: /documentation/develop/build-a-secure-extension/
 topic: Develop
 tags: [beginner, extensions, intermediate, reviews, security, webextensions]
-contributors: [ caitmuenster, irenesmith, tomrittervg, mdnwebdocs-bot, rebloor]
+contributors: [ caitmuenster, irenesmith, tomrittervg, rebloor]
 last_updated_by: caitmuenster
 date: 2020-09-15
 ---

--- a/src/content/documentation/develop/choosing-a-firefox-version-for-extension-development.md
+++ b/src/content/documentation/develop/choosing-a-firefox-version-for-extension-development.md
@@ -4,8 +4,8 @@ title: Choosing a Firefox version for extension development
 permalink: /documentation/develop/choosing-a-firefox-version-for-extension-development/
 topic: Develop
 tags: [add-ons, development, extensions, guide, tools]
-contributors: [rebloor]
-last_updated_by: rebloor
+contributors: [mdnwebdocs-bot, rebloor]
+last_updated_by: mdnwebdocs-bot
 date: 2019-03-18 16:36:22
 ---
 

--- a/src/content/documentation/develop/choosing-a-firefox-version-for-extension-development.md
+++ b/src/content/documentation/develop/choosing-a-firefox-version-for-extension-development.md
@@ -4,8 +4,8 @@ title: Choosing a Firefox version for extension development
 permalink: /documentation/develop/choosing-a-firefox-version-for-extension-development/
 topic: Develop
 tags: [add-ons, development, extensions, guide, tools]
-contributors: [mdnwebdocs-bot, rebloor]
-last_updated_by: mdnwebdocs-bot
+contributors: [rebloor]
+last_updated_by: rebloor
 date: 2019-03-18 16:36:22
 ---
 

--- a/src/content/documentation/develop/debugging.md
+++ b/src/content/documentation/develop/debugging.md
@@ -11,7 +11,6 @@ contributors:
     irenesmith,
     hellosct1,
     janat08,
-    mdnwebdocs-bot,
     MNizam0802,
     ExE-Boss,
     Dietrich,

--- a/src/content/documentation/develop/debugging.md
+++ b/src/content/documentation/develop/debugging.md
@@ -11,6 +11,7 @@ contributors:
     irenesmith,
     hellosct1,
     janat08,
+    mdnwebdocs-bot,
     MNizam0802,
     ExE-Boss,
     Dietrich,

--- a/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
+++ b/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
@@ -5,7 +5,7 @@ permalink: /documentation/develop/developing-extensions-for-firefox-for-android/
 topic: Develop
 tags: [add-ons, beginner, guide, mobile, webextensions]
 contributors:
-  [Rob--W, caitmuenster, rebloor, juraj, ExE-Boss, Ding-Fan, andrewtruongmoz]
+  [Rob--W, caitmuenster, rebloor, juraj, mdnwebdocs-bot, ExE-Boss, Ding-Fan, andrewtruongmoz]
 last_updated_by: Rob--W
 date: 2023-11-12
 ---

--- a/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
+++ b/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
@@ -5,7 +5,7 @@ permalink: /documentation/develop/developing-extensions-for-firefox-for-android/
 topic: Develop
 tags: [add-ons, beginner, guide, mobile, webextensions]
 contributors:
-  [Rob--W, caitmuenster, rebloor, juraj, mdnwebdocs-bot, ExE-Boss, Ding-Fan, andrewtruongmoz]
+  [Rob--W, caitmuenster, rebloor, juraj, ExE-Boss, Ding-Fan, andrewtruongmoz]
 last_updated_by: Rob--W
 date: 2023-11-12
 ---

--- a/src/content/documentation/develop/differences-between-desktop-and-android-extensions.md
+++ b/src/content/documentation/develop/differences-between-desktop-and-android-extensions.md
@@ -7,6 +7,7 @@ tags: [add-ons, guide, mobile, needsupdate, webextensions]
 contributors:
   [
     caitmuenster,
+    mdnwebdocs-bot,
     ExE-Boss,
     gokulakrishna,
     hellosct1,
@@ -16,7 +17,7 @@ contributors:
     rebloor,
     wbamberg,
   ]
-last_updated_by: rebloor
+last_updated_by: mdnwebdocs-bot
 date: 2020-09-15
 ---
 

--- a/src/content/documentation/develop/differences-between-desktop-and-android-extensions.md
+++ b/src/content/documentation/develop/differences-between-desktop-and-android-extensions.md
@@ -7,7 +7,6 @@ tags: [add-ons, guide, mobile, needsupdate, webextensions]
 contributors:
   [
     caitmuenster,
-    mdnwebdocs-bot,
     ExE-Boss,
     gokulakrishna,
     hellosct1,
@@ -17,7 +16,7 @@ contributors:
     rebloor,
     wbamberg,
   ]
-last_updated_by: mdnwebdocs-bot
+last_updated_by: rebloor
 date: 2020-09-15
 ---
 

--- a/src/content/documentation/develop/extensions-and-the-add-on-id.md
+++ b/src/content/documentation/develop/extensions-and-the-add-on-id.md
@@ -13,6 +13,7 @@ contributors:
     freaktechnik,
     jsantell,
     mconca,
+    mdnwebdocs-bot,
     rebloor,
     Rob--W,
     scheinercc,

--- a/src/content/documentation/develop/extensions-and-the-add-on-id.md
+++ b/src/content/documentation/develop/extensions-and-the-add-on-id.md
@@ -13,7 +13,6 @@ contributors:
     freaktechnik,
     jsantell,
     mconca,
-    mdnwebdocs-bot,
     rebloor,
     Rob--W,
     scheinercc,

--- a/src/content/documentation/develop/firefox-workflow-overview.md
+++ b/src/content/documentation/develop/firefox-workflow-overview.md
@@ -16,7 +16,7 @@ tags:
     webextensions,
     workflow,
   ]
-contributors: [irenesmith, hellosct1, rebloor, ani-sha]
+contributors: [irenesmith, hellosct1, rebloor, mdnwebdocs-bot, ani-sha]
 last_updated_by: ani-sha
 date: 2020-03-24 12:47:00
 ---

--- a/src/content/documentation/develop/firefox-workflow-overview.md
+++ b/src/content/documentation/develop/firefox-workflow-overview.md
@@ -16,7 +16,7 @@ tags:
     webextensions,
     workflow,
   ]
-contributors: [irenesmith, hellosct1, rebloor, mdnwebdocs-bot, ani-sha]
+contributors: [irenesmith, hellosct1, rebloor, ani-sha]
 last_updated_by: ani-sha
 date: 2020-03-24 12:47:00
 ---

--- a/src/content/documentation/develop/getting-started-with-web-ext.md
+++ b/src/content/documentation/develop/getting-started-with-web-ext.md
@@ -8,7 +8,6 @@ contributors:
   [
     caitmuenster,
     rebloor,
-    mdnwebdocs-bot,
     Sheppy,
     kumar303,
     platy,

--- a/src/content/documentation/develop/getting-started-with-web-ext.md
+++ b/src/content/documentation/develop/getting-started-with-web-ext.md
@@ -8,6 +8,7 @@ contributors:
   [
     caitmuenster,
     rebloor,
+    mdnwebdocs-bot,
     Sheppy,
     kumar303,
     platy,

--- a/src/content/documentation/develop/onboard-upboard-offboard-users.md
+++ b/src/content/documentation/develop/onboard-upboard-offboard-users.md
@@ -13,7 +13,7 @@ tags:
     user-experience,
     webextensions,
   ]
-contributors: [mdnwebdocs-bot, alxwrd, NiklasGollenstede, David263, rebloor, hamatti]
+contributors: [alxwrd, NiklasGollenstede, David263, rebloor, hamatti]
 last_updated_by: hamatti
 date: 2022-10-18
 ---

--- a/src/content/documentation/develop/onboard-upboard-offboard-users.md
+++ b/src/content/documentation/develop/onboard-upboard-offboard-users.md
@@ -13,7 +13,7 @@ tags:
     user-experience,
     webextensions,
   ]
-contributors: [alxwrd, NiklasGollenstede, David263, rebloor, hamatti]
+contributors: [mdnwebdocs-bot, alxwrd, NiklasGollenstede, David263, rebloor, hamatti]
 last_updated_by: hamatti
 date: 2022-10-18
 ---

--- a/src/content/documentation/develop/porting-a-google-chrome-extension.md
+++ b/src/content/documentation/develop/porting-a-google-chrome-extension.md
@@ -8,7 +8,6 @@ contributors:
   [
     jennyevans,
     blossomica,
-    mdnwebdocs-bot,
     aseffasamson,
     rebloor,
     Uemmra3,

--- a/src/content/documentation/develop/porting-a-google-chrome-extension.md
+++ b/src/content/documentation/develop/porting-a-google-chrome-extension.md
@@ -8,6 +8,7 @@ contributors:
   [
     jennyevans,
     blossomica,
+    mdnwebdocs-bot,
     aseffasamson,
     rebloor,
     Uemmra3,

--- a/src/content/documentation/develop/request-the-right-permissions.md
+++ b/src/content/documentation/develop/request-the-right-permissions.md
@@ -5,7 +5,7 @@ permalink: /documentation/develop/request-the-right-permissions/
 topic: Develop
 tags: [add-ons, beginner, extensions, how-to, intermediate, permissions]
 contributors:
-  [caitmuenster, Zearin_Galaurum, mdnwebdocs-bot, rebloor, evilpie, hellosct1, freaktechnik]
+  [caitmuenster, Zearin_Galaurum, rebloor, evilpie, hellosct1, freaktechnik]
 last_updated_by: Zearin_Galaurum
 date: 2021-03-19 
 ---

--- a/src/content/documentation/develop/request-the-right-permissions.md
+++ b/src/content/documentation/develop/request-the-right-permissions.md
@@ -5,7 +5,7 @@ permalink: /documentation/develop/request-the-right-permissions/
 topic: Develop
 tags: [add-ons, beginner, extensions, how-to, intermediate, permissions]
 contributors:
-  [caitmuenster, Zearin_Galaurum, rebloor, evilpie, hellosct1, freaktechnik]
+  [caitmuenster, Zearin_Galaurum, mdnwebdocs-bot, rebloor, evilpie, hellosct1, freaktechnik]
 last_updated_by: Zearin_Galaurum
 date: 2021-03-19 
 ---

--- a/src/content/documentation/develop/temporary-installation-in-firefox.md
+++ b/src/content/documentation/develop/temporary-installation-in-firefox.md
@@ -7,7 +7,6 @@ tags: [webextensions]
 contributors:
   [
     caitmuenster,
-    mdnwebdocs-bot,
     ldevernay,
     rebloor,
     Abhro,

--- a/src/content/documentation/develop/temporary-installation-in-firefox.md
+++ b/src/content/documentation/develop/temporary-installation-in-firefox.md
@@ -7,6 +7,7 @@ tags: [webextensions]
 contributors:
   [
     caitmuenster,
+    mdnwebdocs-bot,
     ldevernay,
     rebloor,
     Abhro,

--- a/src/content/documentation/develop/test-permission-requests.md
+++ b/src/content/documentation/develop/test-permission-requests.md
@@ -4,7 +4,7 @@ title: Test permission requests
 permalink: /documentation/develop/test-permission-requests/
 topic: Develop
 tags: [add-ons, extensions, guide, permissions, testing, webextensions]
-contributors: [rebloor, mdnwebdocs-bot]
+contributors: [rebloor]
 last_updated_by: rebloor
 date: 2019-03-21 12:27:40
 ---

--- a/src/content/documentation/develop/test-permission-requests.md
+++ b/src/content/documentation/develop/test-permission-requests.md
@@ -4,7 +4,7 @@ title: Test permission requests
 permalink: /documentation/develop/test-permission-requests/
 topic: Develop
 tags: [add-ons, extensions, guide, permissions, testing, webextensions]
-contributors: [rebloor]
+contributors: [rebloor, mdnwebdocs-bot]
 last_updated_by: rebloor
 date: 2019-03-21 12:27:40
 ---

--- a/src/content/documentation/develop/testing-persistent-and-restart-features.md
+++ b/src/content/documentation/develop/testing-persistent-and-restart-features.md
@@ -15,8 +15,8 @@ tags:
     web-ext,
     webextensions,
   ]
-contributors: [freaktechnik, Rob--W, rebloor, tophf, Dietrich]
-last_updated_by: rebloor
+contributors: [mdnwebdocs-bot, freaktechnik, Rob--W, rebloor, tophf, Dietrich]
+last_updated_by: mdnwebdocs-bot
 date: 2019-03-18 18:03:56
 ---
 

--- a/src/content/documentation/develop/testing-persistent-and-restart-features.md
+++ b/src/content/documentation/develop/testing-persistent-and-restart-features.md
@@ -15,8 +15,8 @@ tags:
     web-ext,
     webextensions,
   ]
-contributors: [mdnwebdocs-bot, freaktechnik, Rob--W, rebloor, tophf, Dietrich]
-last_updated_by: mdnwebdocs-bot
+contributors: [freaktechnik, Rob--W, rebloor, tophf, Dietrich]
+last_updated_by: rebloor
 date: 2019-03-18 18:03:56
 ---
 

--- a/src/content/documentation/develop/user-experience-best-practices.md
+++ b/src/content/documentation/develop/user-experience-best-practices.md
@@ -6,6 +6,7 @@ topic: Develop
 tags: [add-ons, extensions, guide, ui, ux]
 contributors:
   [
+    mdnwebdocs-bot,
     MeridelW,
     andrewtruongmoz,
     rebloor,
@@ -16,7 +17,7 @@ contributors:
     atsay,
     bryanyou,
   ]
-last_updated_by: rebloor
+last_updated_by: mdnwebdocs-bot
 date: 2019-03-18 17:05:14
 ---
 

--- a/src/content/documentation/develop/user-experience-best-practices.md
+++ b/src/content/documentation/develop/user-experience-best-practices.md
@@ -6,7 +6,6 @@ topic: Develop
 tags: [add-ons, extensions, guide, ui, ux]
 contributors:
   [
-    mdnwebdocs-bot,
     MeridelW,
     andrewtruongmoz,
     rebloor,
@@ -17,7 +16,7 @@ contributors:
     atsay,
     bryanyou,
   ]
-last_updated_by: mdnwebdocs-bot
+last_updated_by: rebloor
 date: 2019-03-18 17:05:14
 ---
 

--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -19,6 +19,7 @@ contributors:
     kumar303,
     lfilho,
     LowerDimensions,
+    mdnwebdocs-bot,
     niharikak101,
     noraj,
     rebloor,

--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -19,7 +19,6 @@ contributors:
     kumar303,
     lfilho,
     LowerDimensions,
-    mdnwebdocs-bot,
     niharikak101,
     noraj,
     rebloor,

--- a/src/content/documentation/manage/updating-your-extension.md
+++ b/src/content/documentation/manage/updating-your-extension.md
@@ -7,6 +7,7 @@ tags: [update, manage, distribution]
 contributors:
   [
     Wulf,
+    mdnwebdocs-bot,
     rebloor,
     JayFields,
     andrewtruongmoz,

--- a/src/content/documentation/manage/updating-your-extension.md
+++ b/src/content/documentation/manage/updating-your-extension.md
@@ -7,7 +7,6 @@ tags: [update, manage, distribution]
 contributors:
   [
     Wulf,
-    mdnwebdocs-bot,
     rebloor,
     JayFields,
     andrewtruongmoz,

--- a/src/content/documentation/publish/create-an-appealing-listing.md
+++ b/src/content/documentation/publish/create-an-appealing-listing.md
@@ -6,13 +6,14 @@ topic: Publish
 tags: [add-ons, beginner, guide, publishing, webextension]
 contributors:
   [
+    mdnwebdocs-bot,
     wbamberg,
     bravetoaster2,
     caitmuenster,
     andrewtruongmoz,
     rebloor,
   ]
-last_updated_by: rebloor
+last_updated_by: mdnwebdocs-bot
 date: 2019-03-18 17:05:25
 ---
 

--- a/src/content/documentation/publish/create-an-appealing-listing.md
+++ b/src/content/documentation/publish/create-an-appealing-listing.md
@@ -6,14 +6,13 @@ topic: Publish
 tags: [add-ons, beginner, guide, publishing, webextension]
 contributors:
   [
-    mdnwebdocs-bot,
     wbamberg,
     bravetoaster2,
     caitmuenster,
     andrewtruongmoz,
     rebloor,
   ]
-last_updated_by: mdnwebdocs-bot
+last_updated_by: rebloor
 date: 2019-03-18 17:05:25
 ---
 

--- a/src/content/documentation/publish/firefox-add-on-distribution-agreement.md
+++ b/src/content/documentation/publish/firefox-add-on-distribution-agreement.md
@@ -8,6 +8,7 @@ contributors:
   [
     kewisch,
     omnicorpltd,
+    mdnwebdocs-bot,
     shiy23,
     edprince,
     hatem45,

--- a/src/content/documentation/publish/firefox-add-on-distribution-agreement.md
+++ b/src/content/documentation/publish/firefox-add-on-distribution-agreement.md
@@ -8,7 +8,6 @@ contributors:
   [
     kewisch,
     omnicorpltd,
-    mdnwebdocs-bot,
     shiy23,
     edprince,
     hatem45,

--- a/src/content/documentation/publish/package-your-extension.md
+++ b/src/content/documentation/publish/package-your-extension.md
@@ -9,7 +9,6 @@ contributors:
     potterwrit,
     irenesmith,
     rebloor,
-    mdnwebdocs-bot,
     Alston,
     andrewtruongmoz,
     julienw,

--- a/src/content/documentation/publish/package-your-extension.md
+++ b/src/content/documentation/publish/package-your-extension.md
@@ -9,6 +9,7 @@ contributors:
     potterwrit,
     irenesmith,
     rebloor,
+    mdnwebdocs-bot,
     Alston,
     andrewtruongmoz,
     julienw,

--- a/src/content/documentation/publish/signing-and-distribution-overview.md
+++ b/src/content/documentation/publish/signing-and-distribution-overview.md
@@ -9,7 +9,6 @@ contributors:
     caitmuenster,
     Kaligule,
     chrisdavidmills,
-    mdnwebdocs-bot,
     musakarakas,
     MeridelW,
     jvillalobos,

--- a/src/content/documentation/publish/signing-and-distribution-overview.md
+++ b/src/content/documentation/publish/signing-and-distribution-overview.md
@@ -9,6 +9,7 @@ contributors:
     caitmuenster,
     Kaligule,
     chrisdavidmills,
+    mdnwebdocs-bot,
     musakarakas,
     MeridelW,
     jvillalobos,

--- a/src/content/documentation/publish/source-code-submission.md
+++ b/src/content/documentation/publish/source-code-submission.md
@@ -4,7 +4,7 @@ title: Source code submission
 permalink: /documentation/publish/source-code-submission/
 topic: Publish
 tags: [add-ons, distribution, extensions, review-policy]
-contributors: [kewisch, One, rebloor, wbamberg, atsay]
+contributors: [kewisch, mdnwebdocs-bot, One, rebloor, wbamberg, atsay]
 last_updated_by: kewisch
 date: 2019-06-10 06:33:38
 ---

--- a/src/content/documentation/publish/source-code-submission.md
+++ b/src/content/documentation/publish/source-code-submission.md
@@ -4,7 +4,7 @@ title: Source code submission
 permalink: /documentation/publish/source-code-submission/
 topic: Publish
 tags: [add-ons, distribution, extensions, review-policy]
-contributors: [kewisch, mdnwebdocs-bot, One, rebloor, wbamberg, atsay]
+contributors: [kewisch, One, rebloor, wbamberg, atsay]
 last_updated_by: kewisch
 date: 2019-06-10 06:33:38
 ---


### PR DESCRIPTION
Removes mdnwebdocs-bot from contributors and last updated by on pages. Formatting suggested it's a GitHub account when it isn't. 
![image](https://github.com/mozilla/extension-workshop/assets/7352080/5578cca2-d09b-4ec1-bf09-32898b1724b8)
See [Bug 1867230](https://bugzilla.mozilla.org/show_bug.cgi?id=1867230)