### PR TITLE
Add Manifest V3 compatibility data for Android 

### DIFF
--- a/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
+++ b/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
@@ -254,13 +254,13 @@ If your add-on fails to run, check these messages as they may provide informatio
 
 ## Manifest V3 compatibility
 
-Firefox for Android does not have full feature parity with the desktop version of Firefox. There are several known issues with Firefox for Android that may lead to a sub-optimal user experience. As a result, we recommend that developers targeting Android use Manifest V2.
+Firefox for Android doesn't have full feature parity with the desktop version of Firefox. There are several known issues with Firefox for Android that can lead to a poor user experience. Therefore, it's recommended you use Manifest V2 for extensions targeting Firefox for Android.
 
 | Issue description | Tracking bug |
 | --- | --- |
-| Background service workers are not supported on Firefox for Android. Instead, use [event pages](/documentation/develop/manifest-v3-migration-guide.md#event-pages-and-backward-compatibility). | [Bug&nbsp;1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659) |
-| Firefox for Android does not have a visual indicator when an extension has a pending host_permissions grant request for the user. | [Bug&nbsp;1820867](https://bugzilla.mozilla.org/show_bug.cgi?id=1820867) |
-| Users cannot edit an extension's host permission grants in the Firefox for Android's Add-ons Manager. | [Bug&nbsp;1812125](https://bugzilla.mozilla.org/show_bug.cgi?id=1812125) |
+| Background service workers aren't supported on Firefox for Android. Instead, use [event pages](/documentation/develop/manifest-v3-migration-guide.md#event-pages-and-backward-compatibility). | [Bug&nbsp;1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659) |
+| Firefox for Android doesn't visually indicate when an extension has a pending `"host_permissions"` grant request for the user. | [Bug&nbsp;1820867](https://bugzilla.mozilla.org/show_bug.cgi?id=1820867) |
+| Users can't edit an extension's host permission grants in Add-ons Manager on Firefox for Android. | [Bug&nbsp;1812125](https://bugzilla.mozilla.org/show_bug.cgi?id=1812125) |
 
 {% endcapture %}
 {% include modules/one-column.liquid,

--- a/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
+++ b/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
@@ -258,7 +258,7 @@ Firefox for Android does not have full feature parity with the desktop version o
 
 | Issue description | Tracking bug |
 | --- | --- |
-| Background service workers are not supported on Firefox for Android. | [Bug&nbsp;1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659) |
+| Background service workers are not supported on Firefox for Android. Instead, use [event pages](/documentation/develop/manifest-v3-migration-guide.md#event-pages-and-backward-compatibility). | [Bug&nbsp;1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659) |
 | Firefox for Android does not have a visual indicator when an extension has a pending host_permissions grant request for the user. | [Bug&nbsp;1820867](https://bugzilla.mozilla.org/show_bug.cgi?id=1820867) |
 | Users cannot edit an extension's host permission grants in the Firefox for Android's Add-ons Manager. | [Bug&nbsp;1812125](https://bugzilla.mozilla.org/show_bug.cgi?id=1812125) |
 

--- a/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
+++ b/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
@@ -250,4 +250,22 @@ If your add-on fails to run, check these messages as they may provide informatio
   content: content
 %}
 
+{% capture content %}
+
+## Manifest V3 compatibility
+
+Firefox for Android does not have full feature parity with the desktop version of Firefox. There are several known issues with Firefox for Android that may lead to a sub-optimal user experience. As a result, we recommend that developers targeting Android use Manifest V2.
+
+| Issue description | Tracking bug |
+| --- | --- |
+| Background service workers are not supported on Firefox for Android. | [Bug&nbsp;1573659](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659) |
+| Firefox for Android does not have a visual indicator when an extension has a pending host_permissions grant request for the user. | [Bug&nbsp;1820867](https://bugzilla.mozilla.org/show_bug.cgi?id=1820867) |
+| Users cannot edit an extension's host permission grants in the Firefox for Android's Add-ons Manager. | [Bug&nbsp;1812125](https://bugzilla.mozilla.org/show_bug.cgi?id=1812125) |
+
+{% endcapture %}
+{% include modules/one-column.liquid,
+    id: "mv3-compatibility"
+    content: content
+%}
+
 <!-- END: Single Column Body Module -->

--- a/src/content/documentation/develop/differences-between-desktop-and-android-extensions.md
+++ b/src/content/documentation/develop/differences-between-desktop-and-android-extensions.md
@@ -3,7 +3,7 @@ layout: sidebar
 title: Differences between desktop and Android extensions
 permalink: /documentation/develop/differences-between-desktop-and-android-extensions/
 topic: Develop
-tags: [add-ons, guide, mobile, needsupdate, webextensions]
+tags: [add-ons, guide, mobile, webextensions]
 contributors:
   [
     caitmuenster,
@@ -15,9 +15,10 @@ contributors:
     PikadudeNo1,
     rebloor,
     wbamberg,
+    dotproto,
   ]
-last_updated_by: rebloor
-date: 2020-09-15
+last_updated_by: dotproto
+date: 2023-12-01
 ---
 
 <!-- Page Hero Banner -->
@@ -39,9 +40,7 @@ There are some important distinctions to be aware of when developing an extensio
 
 {% capture content_with_toc %}
 
-::: note alert
-Only a limited number of [recommended extensions](/documentation/publish/recommended-extensions/) are supported for Firefox for Android. Look out for updates on the [add-ons blog](https://blog.mozilla.org/addons/category/mobile?utm_source=extensionworkshop.com&utm_medium=dev-article&utm_content=differences-between-desktop-and-android-extensions).
-:::
+{%- include android-alert.liquid -%}
 
 Firefox for Android offers a subset of the WebExtensions APIs available to the desktop version of Firefox. Some of these differences are due to the nature of the Android environment and therefore the features Firefox can implement, others are where Firefox for Android does not offer all the desktop features. This article explores these differences and how they affect your add-on development.
 

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -22,7 +22,7 @@ date: 2023-03-03
 
 Manifest V3 became generally available in Firefox 109 after being available as a developer preview from Firefox 101. This page details what's changed and how you adapt your extensions to take advantage of Manifest V3.
 
-If you are planning to support Android, see the [Developing extensions for Firefox for Android](/documentation/develop/developing-extensions-for-firefox-for-android/#mv3-compatibility) page for additional guidance.
+See the [Developing extensions for Firefox for Android](/documentation/develop/developing-extensions-for-firefox-for-android/#mv3-compatibility) page for additional guidance if you plan to support Firefox for Android.
 
 {% endcapture %}
 {% include modules/page-hero.liquid,
@@ -60,7 +60,6 @@ This section details the Manifest V3 changes made to Firefox.
 %}
 
 {% capture content %}
-
 
 ### Manifest version
 
@@ -377,6 +376,4 @@ The format of the top-level manifest.json `version` key in Firefox has evolved a
 %}
 
 <!-- END: Single Column Body Module -->
-
-
 

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -33,11 +33,11 @@ Manifest V3 became generally available in Firefox 109 after being available as a
 
 ## What is Manifest V3?
 
-Manifest v3 (MV3) is the umbrella term for several foundational changes to the WebExtensions API in Firefox. The name refers to the declared `manifest_version` key in each extension’s [manifest.json](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
+Manifest V3 (MV3) is the umbrella term for several foundational changes to the WebExtensions API in Firefox. The name refers to the declared `manifest_version` key in each extension’s [manifest.json](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) file.
 
-The Manifest v3 changes apply to extensions for Safari, Firefox, and Chromium-based browsers – such as Chrome, Edge, and Opera. While the goal is to maintain a high degree of compatibility between the Firefox, Safari, and Chromium extension platforms, our implementation diverges where we think it matters and where our values point to a different direction.
+The Manifest V3 changes apply to extensions for Safari, Firefox, and Chromium-based browsers – such as Chrome, Edge, and Opera. While the goal is to maintain a high degree of compatibility between the Firefox, Safari, and Chromium extension platforms, our implementation diverges where we think it matters and where our values point to a different direction.
 
-This article discusses the changes introduced with Manifest v3 in Firefox and highlights where they diverge from the Chrome and Safari implementation.
+This article discusses the changes introduced with Manifest V3 in Firefox and highlights where they diverge from the Chrome and Safari implementation.
 
 {% endcapture %}
 {% include modules/column-w-toc.liquid,
@@ -338,7 +338,7 @@ To migrate your extension, rewrite the manifest.json key [‘web_accessible_reso
 
 As part of its Manifest V3 implementation, Chromium introduces [promise](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview#promises) support to many methods with the goal of eventually supporting promises on all appropriate methods. This will provide for greater compatibility between Firefox and Chrome extensions, given that Firefox already supports promises when using the `browser.*` namespace.
 
-In Manifest v2, Firefox extensions support the use of the `chrome.*` namespace with APIs that provide asynchronous event handling using callbacks. In Manifest v3, Firefox supports promises for asynchronous events in the `chrome.*` namespace.
+In Manifest v2, Firefox extensions support the use of the `chrome.*` namespace with APIs that provide asynchronous event handling using callbacks. In Manifest V3, Firefox supports promises for asynchronous events in the `chrome.*` namespace.
 
 {% endcapture %}
 {% include modules/one-column.liquid,

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -22,6 +22,8 @@ date: 2023-03-03
 
 Manifest V3 became generally available in Firefox 109 after being available as a developer preview from Firefox 101. This page details what's changed and how you adapt your extensions to take advantage of Manifest V3.
 
+If you are planning to support Android, see the [Developing extensions for Firefox for Android](/documentation/develop/developing-extensions-for-firefox-for-android/#mv3-compatibility) page for additional guidance.
+
 {% endcapture %}
 {% include modules/page-hero.liquid,
     content: page_hero_banner_content
@@ -58,6 +60,7 @@ This section details the Manifest V3 changes made to Firefox.
 %}
 
 {% capture content %}
+
 
 ### Manifest version
 
@@ -374,4 +377,6 @@ The format of the top-level manifest.json `version` key in Firefox has evolved a
 %}
 
 <!-- END: Single Column Body Module -->
+
+
 

--- a/src/content/documentation/develop/ux-guidelines-for-mobile-extensions.md
+++ b/src/content/documentation/develop/ux-guidelines-for-mobile-extensions.md
@@ -1,15 +1,16 @@
 ---
 layout: sidebar
-title: Differences between desktop and Android extensions
+title: User experience guidelines for mobile extensions
 permalink: /documentation/develop/user-experience-guidelines-for-mobile-extensions/
 topic: Develop
 tags: [add-ons, guide, mobile, webextensions, ux, user-experience]
 contributors:
   [
-    caitmuenster
+    caitmuenster,
+    dotproto
   ]
-last_updated_by: caitmuenster
-date: 2020-10-19
+last_updated_by: dotproto
+date: 2023-12-01
 ---
 
 <!-- Page Hero Banner -->
@@ -33,9 +34,7 @@ Make your extension seamlessly integrate with Firefox for Android.
 
 ## Introduction
 
-::: note alert
-Only a limited number of [recommended extensions](/documentation/publish/recommended-extensions/) are supported for Firefox for Android. Look out for updates on the [add-ons blog](https://blog.mozilla.org/addons/category/mobile?utm_source=extensionworkshop.com&utm_medium=dev-article&utm_content=differences-between-desktop-and-android-extensions).
-:::
+{%- include android-alert.liquid -%}
 
 To make sure your users have a great experience with your extension on Firefox for Android, you want to ensure your extension’s user interface integrates well with the browser.
 

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -400,6 +400,10 @@
                   {
                     "title": "Debug your extension",
                     "id": "debug-your-extension"
+                  },
+                  {
+                    "title": "Manifest V3 compatibility",
+                    "id": "mv3-compatibility"
                   }
                 ]
               },

--- a/src/includes/android-alert.liquid
+++ b/src/includes/android-alert.liquid
@@ -1,0 +1,4 @@
+
+::: note alert
+Only a limited number of [recommended extensions](/documentation/publish/recommended-extensions/) are supported for Firefox for Android. Look out for updates on the [add-ons blog](https://blog.mozilla.org/addons/category/mobile?utm_source=extensionworkshop.com&utm_medium=dev-article&utm_content=differences-between-desktop-and-android-extensions).
+:::


### PR DESCRIPTION
This PR adds a list of issues that developers targeting Manifest V3 and Android should be aware of. This change is being made in support of mozilla/addons-linter#5110.