### PR TITLE
Document default build environment that reviewers use for building add-ons in absense of explicit instructions

### DIFF
--- a/src/content/documentation/publish/source-code-submission.md
+++ b/src/content/documentation/publish/source-code-submission.md
@@ -109,7 +109,7 @@ Should any of the above differ from your build environment, it is essential that
 
 {% endcapture %}
 {% include modules/one-column.liquid,
-  id: "default-build-environment"
+  id: "default-reviewer-build-environment"
   content: content
 %}
 

--- a/src/content/documentation/publish/source-code-submission.md
+++ b/src/content/documentation/publish/source-code-submission.md
@@ -105,7 +105,7 @@ Reviewers will try to replicate your build environment if specified. However, if
 - Node 20 LTS and npm 10
 - 35GB of free disk space
 
-Should any of the above differ from your build environment, it is essential that you let the reviewers know about it via the README file in your source submission otherwise the build might not match and your submission may get rejected.
+You must let the reviewers know if any of the above differs from your build environment. Do this in the README file in your source submission. Otherwise, the reviewer's build might not match yours, and your submission may be rejected.
 
 {% endcapture %}
 {% include modules/one-column.liquid,

--- a/src/content/documentation/publish/source-code-submission.md
+++ b/src/content/documentation/publish/source-code-submission.md
@@ -63,14 +63,21 @@ To reproduce the build, the reviewer runs the instructions you provided and then
 - details, including required version and installation instructions, of any tools or utilities that need to be downloaded, for example, [yuicompressor](http://yui.github.io/yuicompressor/).
 - a list of all the commands to generate an identical copy of the extension from the source code, for example, npm install or a grunt target. Ideally, you should include every command in the build script file.
 
+Reviewers will try to replicate your build environment if specified. However, if you do not specify the build environment, here's the default build environment that reviewers use:
+
+- Latest Ubuntu LTS (Desktop edition) virtualized via VirtualBox running on an x64_84 host
+- 10GB of system memory (RAM), 6 cores of vCPU
+- Latest Node LTS and corresponding npm
+- 50GB of disk space
+
+Should any of the above differ from your build environment, it is essential that you let the reviewers know about it via the README file in your source submission otherwise the build might not match and your submission may get rejected.
+
 The tools you use to minify, or concatenate your source code:
 
 - must be open source: we cannot verify a build made with commercial tools.
 - cannot be web-based: all review builds are run locally. Using a web-based tool doesn’t allow the reviewers to be certain that your sources match the minified code. Some web-based tools offer a version that can be run locally, in which case provide a script to run the tool locally.
 
 When using npm, yarn, or other package management tools that support it, be sure to include the lockfile, for example, `package-lock.json`. Otherwise, reviewers may use a different version resulting in differences between the generated code and that in the extension.
-
-Assume the reviewer hasn’t installed any developer tools on their computer, that is, make sure you include all the set-up and build instructions to create your code. However, you don’t need to describe how to install common tools such as npm or node.
 
 Tip: Use a build target relative to the directory containing the source, such as a `dist` subfolder. This makes it easier for the reviewer to locate your extension’s built code.
 

--- a/src/content/documentation/publish/source-code-submission.md
+++ b/src/content/documentation/publish/source-code-submission.md
@@ -63,15 +63,6 @@ To reproduce the build, the reviewer runs the instructions you provided and then
 - details, including required version and installation instructions, of any tools or utilities that need to be downloaded, for example, [yuicompressor](http://yui.github.io/yuicompressor/).
 - a list of all the commands to generate an identical copy of the extension from the source code, for example, npm install or a grunt target. Ideally, you should include every command in the build script file.
 
-Reviewers will try to replicate your build environment if specified. However, if you do not specify the build environment, here's the default build environment that reviewers use:
-
-- Ubuntu 22.04 LTS (Desktop edition)
-- 10GB of system memory (RAM), 6 cores of vCPU
-- Node 20 LTS and npm 10
-- 35GB of free disk space
-
-Should any of the above differ from your build environment, it is essential that you let the reviewers know about it via the README file in your source submission otherwise the build might not match and your submission may get rejected.
-
 The tools you use to minify, or concatenate your source code:
 
 - must be open source: we cannot verify a build made with commercial tools.
@@ -103,6 +94,24 @@ You can add source code to an existing add-on version. To do this, open [My Add-
 
 <!-- END: Content with Table of Contents -->
 <!-- Single Column Body Module -->
+
+{% capture content %}
+
+### Default reviewer build environment
+Reviewers will try to replicate your build environment if specified. However, if you do not specify the build environment, here's the default build environment that reviewers use:
+
+- Ubuntu 22.04 LTS (Desktop edition)
+- 10GB of system memory (RAM), 6 cores of vCPU
+- Node 20 LTS and npm 10
+- 35GB of free disk space
+
+Should any of the above differ from your build environment, it is essential that you let the reviewers know about it via the README file in your source submission otherwise the build might not match and your submission may get rejected.
+
+{% endcapture %}
+{% include modules/one-column.liquid,
+  id: "default-build-environment"
+  content: content
+%}
 
 {% capture content %}
 

--- a/src/content/documentation/publish/source-code-submission.md
+++ b/src/content/documentation/publish/source-code-submission.md
@@ -65,7 +65,7 @@ To reproduce the build, the reviewer runs the instructions you provided and then
 
 Reviewers will try to replicate your build environment if specified. However, if you do not specify the build environment, here's the default build environment that reviewers use:
 
-- Latest Ubuntu LTS (Desktop edition) virtualized via VirtualBox running on an x64_84 host
+- Latest Ubuntu LTS (Desktop edition) virtualized via VirtualBox running on an x86_64 host
 - 10GB of system memory (RAM), 6 cores of vCPU
 - Latest Node LTS and corresponding npm
 - 50GB of disk space

--- a/src/content/documentation/publish/source-code-submission.md
+++ b/src/content/documentation/publish/source-code-submission.md
@@ -65,10 +65,10 @@ To reproduce the build, the reviewer runs the instructions you provided and then
 
 Reviewers will try to replicate your build environment if specified. However, if you do not specify the build environment, here's the default build environment that reviewers use:
 
-- Latest Ubuntu LTS (Desktop edition) virtualized via VirtualBox running on an x86_64 host
+- Ubuntu 22.04 LTS (Desktop edition)
 - 10GB of system memory (RAM), 6 cores of vCPU
-- Latest Node LTS and corresponding npm
-- 50GB of disk space
+- Node 20 LTS and npm 10
+- 35GB of free disk space
 
 Should any of the above differ from your build environment, it is essential that you let the reviewers know about it via the README file in your source submission otherwise the build might not match and your submission may get rejected.
 

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -793,6 +793,10 @@
                     "id": "provide-your-extension-source-code"
                   },
                   {
+                    "title": "Default reviewer build environment",
+                    "id": "default-reviewer-build-environment"
+                  },
+                  {
                     "title": "Use of obfuscated code",
                     "id": "use-of-obfuscated-code"
                   },


### PR DESCRIPTION
- Explicitly spell out what environment reviewers are using to build add-ons in the absence of details from developers
- Serve as documentation to developers who specify some build instructions but not all (if only the Node version is mentioned, but the developer builds their add-ons on newer Mac devices (arm64) while the reviewer is trying to build it on an x86 device) in case of build mismatches 
