### PR TITLE
`web-ext run --arg` - Mention `--remote-debugging-port`

### DIFF
--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -435,8 +435,13 @@ Environment variable: `$WEB_EXT_TARGET`
 Additional CLI options passed to the Browser binary. Example:
 
 ```shell
---arg="--search=mozilla" --arg="--new-tab=https://duckduckgo.com"
+web-ext run --arg="--search=mozilla" --arg="--new-tab=https://duckduckgo.com"
 ```
+
+```shell
+web-ext run --arg="--remote-debugging-port=9229" --target chromium
+```
+
 </section>
 
 <section id="chromium-binary">


### PR DESCRIPTION
I'm trying to debug a crashing background page extension, I had a hard time finding `--arg` as a way to remotely debug the background page. Given it's a _relatively_ common flag, I think it would be good to mention it for discoverability.