### PR TITLE
Add email troubleshooting guide

### DIFF
--- a/src/content/documentation/publish/developer-accounts.md
+++ b/src/content/documentation/publish/developer-accounts.md
@@ -65,19 +65,14 @@ If you believe your account has been incorrectly blocked, please email amo-admin
 
 ## Issues receiving reviewer emails
 
-When an email doesn’t get delivered the cause can vary widely from relatively simple to technically complex issues. Below are several of the more common reasons why you may not have received emails sent from our https://addons.mozilla.org (AMO) platform.
+If you're expecting but haven't received emails from the https://addons.mozilla.org (AMO) platform, check that:
 
-The two most common explanations are usually: 
+1. Your Mozilla account's primary email address is correct. To update it, see the support article [Change primary email address on Mozilla account](https://support.mozilla.org/en-US/kb/change-primary-email-address-firefox-accounts).
+1. The email isn't in your spam or junk folder. If it is, consider adding the AMO email domain (@mozilla.org) to your [approved senders](https://clean.email/blog/email-security/how-to-whitelist-an-email) list.
+1. Your inbox isn't full.
+1. Your mail provider hasn't implemented a security filter that blocked the email delivery.
 
-1. The email is sitting in a spam or junk folder in the recipient's inbox.
-    * To remedy this, you can add the AMO email domain (@mozilla.org) to your [approved senders](https://clean.email/blog/email-security/how-to-whitelist-an-email) list.
-1. The email was blocked from being delivered by a security filter. In this case, the email was filtered after being received by the email server – it never even reached the recipient's personal inbox.
-
-Another potential issue is if the primary email address associated with your Mozilla account no longer exists or if you no longer have access to it. In this case, please follow the instructions [here](https://support.mozilla.org/en-US/kb/change-primary-email-address-firefox-accounts) to update the email address on your Mozilla account.
-
-One final item to check is whether or not your inbox is full. If it is, you will need to delete some messages before you are able to start receiving emails again.
-
-If you are still experiencing problems receiving emails from the AMO platform we encourage you to post in our [add-ons community forum](https://discourse.mozilla.org/c/add-ons/35) with the specific details of your issue.
+If you're still experiencing issues after making these checks, posting details of your issue to the [add-ons community forum](https://discourse.mozilla.org/c/add-ons/35) may help.
 
 {% endcapture %}
 {% include modules/one-column.liquid,

--- a/src/content/documentation/publish/developer-accounts.md
+++ b/src/content/documentation/publish/developer-accounts.md
@@ -63,7 +63,7 @@ If you believe your account has been incorrectly blocked, please email amo-admin
 
 {% capture content %}
 
-## Issues receiving reviewer emails
+## Issues receiving emails from AMO
 
 If you're expecting but haven't received emails from the https://addons.mozilla.org (AMO) platform, check that:
 

--- a/src/content/documentation/publish/developer-accounts.md
+++ b/src/content/documentation/publish/developer-accounts.md
@@ -59,5 +59,32 @@ If you believe your account has been incorrectly blocked, please email amo-admin
 %}
 
 <!-- END: Single Column Body Module -->
+<!-- Single Column Body Module -->
+
+{% capture content %}
+
+## Issues receiving reviewer emails
+
+When an email doesn’t get delivered the cause can vary widely from relatively simple to technically complex issues. Below are several of the more common reasons why you may not have received emails sent from our https://addons.mozilla.org (AMO) platform.
+
+The two most common explanations are usually: 
+
+1. The email is sitting in a spam or junk folder in the recipient's inbox.
+    * To remedy this, you can add the AMO email domain (@mozilla.org) to your [approved senders](https://clean.email/blog/email-security/how-to-whitelist-an-email) list.
+1. The email was blocked from being delivered by a security filter. In this case, the email was filtered after being received by the email server – it never even reached the recipient's personal inbox.
+
+Another potential issue is if the primary email address associated with your Mozilla account no longer exists or if you no longer have access to it. In this case, please follow the instructions [here](https://support.mozilla.org/en-US/kb/change-primary-email-address-firefox-accounts) to update the email address on your Mozilla account.
+
+One final item to check is whether or not your inbox is full. If it is, you will need to delete some messages before you are able to start receiving emails again.
+
+If you are still experiencing problems receiving emails from the AMO platform we encourage you to post in our [add-ons community forum](https://discourse.mozilla.org/c/add-ons/35) with the specific details of your issue.
+
+{% endcapture %}
+{% include modules/one-column.liquid,
+  id: "email-issues"
+  content: content
+%}
+
+<!-- END: Single Column Body Module -->
 
 

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -887,7 +887,7 @@
                     "id": "blocked-accounts"
                   },
                   {
-                    "title": "Issues receiving reviewer emails",
+                    "title": "Issues receiving emails from AMO",
                     "id": "email-issues"
                   }
                 ]

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -885,6 +885,10 @@
                   {
                     "title": "Blocked accounts",
                     "id": "blocked-accounts"
+                  },
+                  {
+                    "title": "Issues receiving reviewer emails",
+                    "id": "email-issues"
                   }
                 ]
               },


### PR DESCRIPTION
This PR introduces a new section to the [Developer account](https://extensionworkshop.com/documentation/publish/developer-accounts/) page that covers troubleshooting issues receiving emails from AMO.