### PR TITLE
Add new CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+  
+      - name: Install dependencies
+        run: yarn install --immutable
+  
+      - name: Run tests
+        run: yarn run test-ci
+
+      - name: Make a production build
+        run: yarn build:production

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI](https://github.com/mozilla/extension-workshop/actions/workflows/ci.yml/badge.svg)](https://github.com/mozilla/extension-workshop/actions/workflows/ci.yml)
 [![CircleCI](https://circleci.com/gh/mozilla/extension-workshop/tree/master.svg?style=svg)](https://circleci.com/gh/mozilla/extension-workshop/tree/master)
 
 # Firefox Extension Workshop


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to run a CI job on pull requests and commits landed on the main branch (`master`).