### PR TITLE
Fix title for the web-ext v7 reference page

### DIFF
--- a/src/content/documentation/develop/web-ext-command-reference-v7.md
+++ b/src/content/documentation/develop/web-ext-command-reference-v7.md
@@ -1,6 +1,6 @@
 ---
 layout: sidebar.liquid
-title: web-ext command reference
+title: web-ext v7 command reference
 permalink: /documentation/develop/web-ext-command-reference-v7/
 topic: Develop
 tags: [commands, options, reference, tools, web-ext, webextensions]
@@ -32,8 +32,8 @@ contributors:
     djbrown,
     Robot-Inventor
   ]
-last_updated_by: rebloor
-date: 2024-05-15
+last_updated_by: willdurand
+date: 2024-05-23
 ---
 
 <!-- Page Hero Banner -->


### PR DESCRIPTION
When we type "web-ext" in the search bar, we get two results and both have the same title:

<img width="1512" alt="Screenshot 2024-05-23 at 14 34 55" src="https://github.com/mozilla/extension-workshop/assets/217628/fb045a2f-598d-49e6-b84f-6a38c6ea193e">

This PR addresses that.