### PR TITLE
WEB_EXT_API_APPROVAL_TIMEOUT -> WEB_EXT_APPROVAL_TIMEOUT

### DIFF
--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -585,7 +585,7 @@ Environment variable: `$WEB_EXT_API_SECRET`
 
 Number of milliseconds to wait for approval before giving up. Set to 0 to disable the wait for approval. Defaults to `timeout` if not set.
 
-Environment variable: `$WEB_EXT_API_APPROVAL_TIMEOUT`
+Environment variable: `$WEB_EXT_APPROVAL_TIMEOUT`
 </section>
 
 <section id="amo-base-url">


### PR DESCRIPTION
The "API_" in the environment variable is likely a copy-paste typo from the preceding section. The correct environment variable to use is WEB_EXT_APPROVAL_TIMEOUT.

Fixes confusion caused by https://github.com/mozilla/web-ext/issues/3238