### PR TITLE
Better abbr example for Markdown syntax

### DIFF
--- a/src/content/documentation/publish/create-an-appealing-listing.md
+++ b/src/content/documentation/publish/create-an-appealing-listing.md
@@ -331,8 +331,10 @@ And, when users suggest improvements or highlight issues in the reviews, use the
       <tr>
         <td>Abbreviations</td>
         <td><code>*[abbr]: Abbreviation</code></td>
-        <td><code>*[HTML]: Hyper Text Markup Language</code></td>
-        <td><abbr title="Hypertext Markup Language">HTML</abbr></td>
+        <td><code>
+        HTML is fun!<br/>*[HTML]: Hyper Text Markup Language
+        </code></td>
+        <td><abbr title="Hypertext Markup Language">HTML</abbr> is fun!</td>
       </tr>
       <tr>
         <td>Blockquote</td>


### PR DESCRIPTION
Closes https://github.com/mozilla/addons/issues/15316

After some back and forth with @ioanarusiczki on Slack, the abbr example is misleading. Changes the example to be more clear.

<img width="801" alt="image" src="https://github.com/user-attachments/assets/bb09937e-dae9-475b-8934-db4b128e8fa0" />
