### PR TITLE
Clarify extension ID creation

### DIFF
--- a/src/content/documentation/develop/extensions-and-the-add-on-id.md
+++ b/src/content/documentation/develop/extensions-and-the-add-on-id.md
@@ -34,7 +34,7 @@ date: 2023-10-28
 
 # Extensions and the add-on ID
 
-Firefox add-ons contain a unique ID that is used to distinguish one add-on from any other Firefox add-on.
+Firefox add-ons contain a unique ID, chosen by the developer, that is used to distinguish one add-on from any other Firefox add-on.
 
 Firefox uses an extension's unique ID inside Firefox and on the [addons.mozilla.org](https://addons.mozilla.org/) (AMO) website. For example, it's used by Firefox to check for updates to installed add-ons and to identify which objects (such as data stores) are controlled by the add-on.
 
@@ -106,6 +106,12 @@ See [`browser_specific_settings` in manifest.json](https://developer.mozilla.org
 </aside>
 <article class="module-content grid-x grid-padding-x">
 <div class="cell small-12">
+  
+## Basic workflow with no add-on ID (Manifest V3)
+
+In Manifest V3 an extension ID is required before AMO submission. You can decide the ID yourself - it must be less than 80 characters and have the format `^[a-zA-Z0-9-._]*@[a-zA-Z0-9-._]+$`, such as `myextension@example.org`.
+
+When you submit the extension the extension ID will be checked for uniqueness.
 
 ## Basic workflow with no add-on ID (Manifest V2)
 


### PR DESCRIPTION
AFAICT nowhere in the docs did it say that the developer can come up with the extension ID on their own, and in several places it's suggested that they don't come up with it on their own (ex: testing locally, uploading manifest V2 extensions with no ID).

For manifest V3, the developer must come up with an ID on their own to submit the extension. This confused me for several hours until I joined the addons web chat and got an answer from someone official.  

In this MR I clarified it (I think in the best location) and provided details on the requirements and how to to choose one.

Related: https://github.com/mdn/content/pull/38444 - I also made changes here because this information is spread in multiple places so people might not find one or the other, and without this clarification reading the wrong document could lead someone to think they have the (wrong) answer and stop searching at that point.