### PR TITLE
Add default values for timeouts to web-ext docs

### DIFF
--- a/src/content/documentation/develop/web-ext-command-reference-v7.md
+++ b/src/content/documentation/develop/web-ext-command-reference-v7.md
@@ -625,7 +625,7 @@ Environment variable: `$WEB_EXT_CHANNEL`
 
 #### `--timeout`
 
-Number of milleseconds to wait before giving up on a&nbsp;response from Mozilla's web service. This should always be a number.
+Number of milleseconds to wait before giving up on a&nbsp;response from Mozilla's web service. This should always be a number. _Defaults to 5 minutes (300000 ms)_
 
 Environment variable: `$WEB_EXT_TIMEOUT`
 </section>

--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -583,7 +583,7 @@ Environment variable: `$WEB_EXT_API_SECRET`
 
 #### `--approval-timeout`
 
-Number of milliseconds to wait for approval before giving up. Set to 0 to disable the wait for approval. Defaults to `timeout` if not set.
+Number of milliseconds to wait for approval before giving up. Set to 0 to disable the wait for approval. Defaults to `timeout` if not set. _Defaults to 15 minutes (900000 ms)._
 
 Environment variable: `$WEB_EXT_APPROVAL_TIMEOUT`
 </section>
@@ -631,7 +631,7 @@ Environment variable: `$WEB_EXT_CHANNEL`
 
 #### `--timeout`
 
-Number of milliseconds to wait before giving up on a response from Mozilla's web service. This should always be a number.
+Number of milliseconds to wait before giving up on a response from Mozilla's web service. This should always be a number. _Defaults to 5 minutes (300000 ms)_
 
 Environment variable: `$WEB_EXT_TIMEOUT`
 </section>


### PR DESCRIPTION
I was debugging a timeout issue on one of my extensions and noticed that mozilla provides a few timeout configuration options but doesn't list the default values, which could be good for posterity.