### PR TITLE
Fix typo: WEB_AMO_METADATA -> WEB_EXT_AMO_METADATA

### DIFF
--- a/src/content/documentation/develop/web-ext-command-reference-v7.md
+++ b/src/content/documentation/develop/web-ext-command-reference-v7.md
@@ -653,7 +653,7 @@ Path to a JSON file containing an object with metadata to be passed to the add-o
 This option is only used when combined with `--use-submission-api`.
 :::
 
-Environment variable: `$WEB_AMO_METADATA`
+Environment variable: `$WEB_EXT_AMO_METADATA`
 </section>
 </section> <!-- web-ext-sign -->
 

--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -674,7 +674,7 @@ When publishing an extension update metadata isn't required. If metadata isn't p
 }
 ```
 
-Environment variable: `$WEB_AMO_METADATA`
+Environment variable: `$WEB_EXT_AMO_METADATA`
 </section>
 
 <section id="upload-source-code">


### PR DESCRIPTION
All web-ext environment variables should start with WEB_EXT.

Fixes documentation issue that was reported in https://github.com/mozilla/web-ext/issues/3446