### PR TITLE
Fix built-in consent policy typos

### DIFF
--- a/src/content/documentation/publish/add-on-policies.md
+++ b/src/content/documentation/publish/add-on-policies.md
@@ -13,9 +13,10 @@ contributors:
     jvillalobos,
     wbamberg,
     kmaglione,
+    dotproto,
   ]
-last_updated_by: wagnerand
-date: 2025-08-04
+last_updated_by: dotproto
+date: 2025-09-17
 ---
 
 <!-- Page Hero Banner -->
@@ -185,11 +186,11 @@ The user must be provided with a clear way to control the add-on’s data transm
 
 Add-ons installed in an enterprise environment can bypass asking for data collection consent when they are installed by enterprise policy. For more information, refer to the [enterprise documentation](/documentation/enterprise/enterprise-development/). If the add-on uses Firefox’s built-in data collection and transmission consent experience, then the browser will bypass this by default.
 
-#### If the add-on is only compatible with Firefox 140 or later and uses Firefox’s built-in data collection and transmission consent experience
+#### If the add-on is only compatible with Firefox 140 or later and uses Firefox’s built-in data collection and transmission consent experience:
 
 It must accurately state the data collection practices in the extension manifest, including when it does not collect data, in line with the [Firefox add-on data classification taxonomy](/documentation/develop/firefox-builtin-data-consent/#taxonomy).
 
-#### If the add-on is compatible with Firefox 139 and earlier or uses Firefox’s built-in data collection and transmission consent experience
+#### If the add-on is compatible with Firefox 139 and earlier or does not use Firefox’s built-in data collection and transmission consent experience:
 
 The user must be provided with a clear way to control the add-on’s data transmission immediately after installation of the add-on. If data transmission starts or changes in an add-on update, or the consent and control is introduced in an update, it must be shown to all new and upgrading users immediately after the update.
 


### PR DESCRIPTION
This PR addresses two issues with the current text that made the policies around data transmission consent confusing or difficult to follow.

1. Clarify that the data collection consent rules apply when developers DO NOT use Firefox's built-in consent.
2. Add colons to the consent headers to make it more obvious that the text that follows falls under that header.