### PR TITLE
Updated Android debugging advice

### DIFF
--- a/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
+++ b/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
@@ -47,7 +47,7 @@ Complete some one-off setup tasks on your computer and Android device.
 
 On your development computer:
 
-- Install or update [web-ext](https://github.com/mozilla/web-ext) to version 7.12.0 or later.
+- Install or update [web-ext](https://github.com/mozilla/web-ext) to version 7.12.0 or later. (Always installing or upgrading to the latest version is recommended.)
 - Use the Android Studio [SDK Manager](https://developer.android.com/studio/intro/update.html#sdk-manager) or the [sdkmanager](https://developer.android.com/studio/command-line/sdkmanager.html) command-line tool to install the [Android Platform Tools](https://developer.android.com/studio/releases/platform-tools.html)
 - Make sure you have adb installed ([Linux](https://dl.google.com/android/repository/platform-tools-latest-linux.zip), [Mac](https://dl.google.com/android/repository/platform-tools-latest-darwin.zip), [Windows](https://dl.google.com/android/repository/platform-tools-latest-windows.zip)) and in your `PATH`.
 


### PR DESCRIPTION
This change updates the details about debugging on an Android device:

- updates the recommended base version of web-ext
-  removes the advice about using Nightly only
- list the paired computer and Android editions
- notes that versions don't have to be the same, but should be aligned if issues are encountered
- add the APK names for each edition
- moves cross-reference links to Firefox source docs to the setup section and points back to the set up section from Debug your extension rather than using external links
- other minor grammar changes