### PR TITLE
Issue 1213 tidy up extension id terminology

### DIFF
--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -158,7 +158,9 @@ While a web extension API may be compatible between Firefox and the Chromium-bas
 Cases where the extension behavior may be affected include:
 
 - **URLs in CSS**: Firefox resolves URLs in injected CSS files relative to the CSS file itself, rather than to the page it's injected into.
-- **[Web accessible resources](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources)**: Firefox always use a random UUID to identify an extension in a browser instance. Extensions for Chromium-based browsers can use the [key](https://developer.chrome.com/extensions/manifest/key) property to fix the extension ID on different machines. However, the recommendation practice In Chromium-based browsers is not to use this approach.
+- **[Web accessible resources](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources)**: these are accessed using an ID associated with the extension, where:
+  - Firefox uses the internal UUID, a unique identifier assigned randomly to an extension when it's installed.
+  - Extensions for Chromium-based browsers use an ID assigned to the extension when it is published. However, the [key](https://developer.chrome.com/docs/extensions/reference/manifest/key) property can be used to set this ID.
 - **Content script requests context**: In Chromium-based browsers, when a request is called (for example, using `fetch())` to relative a URL, such as `/api`, from a content script, it is sent to `https://example.com/api`. Firefox uses absolute URLs.
 - **Native messaging**: there are variations in the command-line arguments, manifest key names, and manifest location between Firefox and the Chromium-based browsers.
 

--- a/src/content/documentation/develop/build-a-secure-extension.md
+++ b/src/content/documentation/develop/build-a-secure-extension.md
@@ -75,8 +75,8 @@ Here is a list of best practices you should follow to keep the users of your ext
   If the standard UI components aren’t sufficient for your needs use iframes with [data URLs](https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) to prevent fingerprinting, or add `iframe`s to the extension code so a page can’t interact with your UI content, such as buttons.
 - **Add eslint-plugin-no-unsanitized to ESLint**
   If you make use of ESLint to check your extension code, consider adding `eslint-plugin-no-unsanitized`. This ESLint rules plug-in will flag instances where unsanitized code from APIs or user input could cause issues.
-- **Don't inject moz-extension paths directly**
-  When injected links, includes, or images include paths to `moz-extension://{hash}` a page’s tracking script could use this information to [fingerprint](https://en.wikipedia.org/wiki/Device_fingerprint) the user, as the hash (UUID) is unique to the extension installation and, therefore, the user.
+- **Don’t inject moz-extension paths directly**
+  When injected links, includes, or images include paths to `moz-extension://{internal UUID}` a page’s tracking script could use this information to [fingerprint](https://en.wikipedia.org/wiki/Device_fingerprint) the user, as the internal UUID is unique to the extension installation and, therefore, the user.
   The best way to avoid this issue is to follow the general advice about not injecting content. However, if you believe injecting content is your only practical approach, ensure that moz-extension paths are embedded inside an iframe using a [data URL](https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) or the [srcdoc](https://developer.mozilla.org/docs/Web/HTML/Element/iframe#attr-srcdoc) attribute.
 - **Ensure that third-party libraries are up to date**
   Reputable third-party libraries will be updated when any issues are found. The use of outdated (and potentially insecure) third-party libraries is strongly discouraged and, when a significant risk is identified, AMO may act to block extensions using the out of date code.

--- a/src/content/documentation/develop/build-a-secure-extension.md
+++ b/src/content/documentation/develop/build-a-secure-extension.md
@@ -76,7 +76,7 @@ Here is a list of best practices you should follow to keep the users of your ext
 - **Add eslint-plugin-no-unsanitized to ESLint**
   If you make use of ESLint to check your extension code, consider adding `eslint-plugin-no-unsanitized`. This ESLint rules plug-in will flag instances where unsanitized code from APIs or user input could cause issues.
 - **Don’t inject moz-extension paths directly**
-  When injected links, includes, or images include paths to `moz-extension://{internal UUID}` a page’s tracking script could use this information to [fingerprint](https://en.wikipedia.org/wiki/Device_fingerprint) the user, as the internal UUID is unique to the extension installation and, therefore, the user.
+  When injected links, includes, or images include paths to `moz-extension://{internal UUID}`, a page’s tracking script could use this information to [fingerprint](https://en.wikipedia.org/wiki/Device_fingerprint) the user, as the internal UUID is unique to the extension installation and, therefore, the user.
   The best way to avoid this issue is to follow the general advice about not injecting content. However, if you believe injecting content is your only practical approach, ensure that moz-extension paths are embedded inside an iframe using a [data URL](https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) or the [srcdoc](https://developer.mozilla.org/docs/Web/HTML/Element/iframe#attr-srcdoc) attribute.
 - **Ensure that third-party libraries are up to date**
   Reputable third-party libraries will be updated when any issues are found. The use of outdated (and potentially insecure) third-party libraries is strongly discouraged and, when a significant risk is identified, AMO may act to block extensions using the out of date code.

--- a/src/content/documentation/manage/updating-your-extension.md
+++ b/src/content/documentation/manage/updating-your-extension.md
@@ -83,7 +83,7 @@ A typical update manifest looks something like:
 
 ## Enabling updates to your extension
 
-If your extension is not hosted on AMO, you must specify the location of your update manifest in your extension. For extensions developed with WebExtension APIs, add the following to your manifest:
+If your extension is not hosted on AMO, you must specify the location of your update manifest in your extension. For extensions developed with WebExtension APIs, add this to your manifest:
 
 ```json
 "browser_specific_settings": {
@@ -103,7 +103,7 @@ If your extension is not hosted on AMO, you must specify the location of your up
 
 ## Manifest Structure
 
-The manifest is a JSON file, with a top-level object literal. This object may have the following properties:
+The manifest is a JSON file, with a top-level object literal. This object may have these properties:
 
 <!-- Table -->
 
@@ -111,7 +111,7 @@ The manifest is a JSON file, with a top-level object literal. This object may ha
 
 | Property | Type     | Description                                                                                                                                                                                                                                |
 | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `addons` | `object` | An object containing one entry for each add-on to be updated. For each such entry, the name of the property must be the add-on's UUID, and the value must be an <a href="#addon-objects">object describing the add-on</a> and its updates. |
+| `addons` | `object` | An object containing one entry for each add-on to be updated. For each such entry, the name of the property must be the [add-on's ID](/documentation/develop/extensions-and-the-add-on-id/), and the value must be an <a href="#addon-objects">object describing the add-on</a> and its updates. |
 
 {% endcapture %}
 {% include modules/table.liquid,


### PR DESCRIPTION
This change fixes #1213 by updating references to use the terminal "internal ID", where appropriate. Also, corrects the link to the Chrome article on the manifest.json `key` property, removing the comment about its use not being recommended, as that no longer appears to be the case.