### PR TITLE
Issue 585 descriptions for each page

### DIFF
--- a/src/content/documentation/develop.md
+++ b/src/content/documentation/develop.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar.liquid
 title: Create extensions for Firefox and Firefox for Android
+description: Deep dive into developing Firefox extensions. Get guides on Manifest V3, cross-browser porting, security best practices, and debugging tools for your add-ons.
 permalink: /documentation/develop/
 tags: []
 contributors: [caitmuenster]

--- a/src/content/documentation/develop/about-the-webextensions-api.md
+++ b/src/content/documentation/develop/about-the-webextensions-api.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar.liquid
 title: About the WebExtensions API
+description: Learn the fundamentals of the WebExtensions API. Explore the power of the browser extensions APIs for building robust and feature-rich Firefox add-ons.
 permalink: /documentation/develop/about-the-webextensions-api/
 topic: Develop
 tags: [webextensions, api, firefox]

--- a/src/content/documentation/develop/best-practices-for-collecting-user-data-consents.md
+++ b/src/content/documentation/develop/best-practices-for-collecting-user-data-consents.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar.liquid
 title: Best practices for collecting user data consents
+description: Follow best practices for collecting user data consent in your Firefox extension. Ensure privacy compliance and maintain user trust.
 permalink: /documentation/develop/best-practices-for-collecting-user-data-consents/
 topic: Develop
 tags:

--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar.liquid
 title: Browser compatibility
+description: Check browser compatibility for WebExtension APIs. Ensure your code works across Firefox and other browsers with these compatibility tables.
 permalink: /documentation/develop/browser-compatibility/
 topic: Develop
 tags: [beginner, extensions, webextensions, compatibility, cross-browser]

--- a/src/content/documentation/develop/browser-extension-development-tools.md
+++ b/src/content/documentation/develop/browser-extension-development-tools.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar.liquid
 title: Browser Extension Development Tools
+description: Discover the range of tools for Firefox extension development, including web-ext and boilerplating utilities to streamline your workflow.
 permalink: /documentation/develop/browser-extension-development-tools/
 topic: Develop
 tags:

--- a/src/content/documentation/develop/build-a-secure-extension.md
+++ b/src/content/documentation/develop/build-a-secure-extension.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar.liquid
 title: Build a secure extension
+description: Learn best practices to build a secure Firefox extension. Protect your users and your add-on by implementing key security and privacy measures.
 permalink: /documentation/develop/build-a-secure-extension/
 topic: Develop
 tags: [beginner, extensions, intermediate, reviews, security, webextensions]

--- a/src/content/documentation/develop/build-an-accessible-extension.md
+++ b/src/content/documentation/develop/build-an-accessible-extension.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Build an accessible extension
+description: Design and develop an accessible Firefox extension. Ensure your add-on can be used by everyone, regardless of ability.
 permalink: /documentation/develop/build-an-accessible-extension/
 topic: Develop
 tags: [development, extensions, ui, user-interface, ux, webextensions]

--- a/src/content/documentation/develop/choosing-a-firefox-version-for-extension-development.md
+++ b/src/content/documentation/develop/choosing-a-firefox-version-for-extension-development.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Choosing a Firefox version for extension development
+description: Learn about the characteristics of Firefox versions for extension development. Understand the differences between release channels for testing your add-on.
 permalink: /documentation/develop/choosing-a-firefox-version-for-extension-development/
 topic: Develop
 tags: [add-ons, development, extensions, guide, tools]

--- a/src/content/documentation/develop/debugging.md
+++ b/src/content/documentation/develop/debugging.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Debugging
+description: Master the tools and techniques for debugging and testing your Firefox extension. Resolve issues quickly using the Developer Tools window.
 permalink: /documentation/develop/debugging/
 topic: Develop
 tags: [debugging, firefox, guide, mozilla, webextensions]

--- a/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
+++ b/src/content/documentation/develop/developing-extensions-for-firefox-for-android.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Developing extensions for Firefox for Android
+description: Extend your reach to Firefox for Android. Learn the capabilities and necessary steps for developing mobile extensions for the browser.
 permalink: /documentation/develop/developing-extensions-for-firefox-for-android/
 topic: Develop
 tags: [add-ons, beginner, guide, mobile, webextensions]

--- a/src/content/documentation/develop/differences-between-desktop-and-android-extensions.md
+++ b/src/content/documentation/develop/differences-between-desktop-and-android-extensions.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Differences between desktop and Android extensions
+description: Understand the key differences between desktop and Firefox for Android extensions. Optimize your add-on for the mobile environment.
 permalink: /documentation/develop/differences-between-desktop-and-android-extensions/
 topic: Develop
 tags: [add-ons, guide, mobile, webextensions]

--- a/src/content/documentation/develop/extensions-and-the-add-on-id.md
+++ b/src/content/documentation/develop/extensions-and-the-add-on-id.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
-title: Extensions and the Add-on ID
+title: Extensions and the add-on ID
+description: Learn about the structure and importance of your extension's add-on ID. Crucial information for signing and distribution of your Firefox add-on.
 permalink: /documentation/develop/extensions-and-the-add-on-id/
 topic: Develop
 tags: [webextensions]

--- a/src/content/documentation/develop/firefox-builtin-data-consent.md
+++ b/src/content/documentation/develop/firefox-builtin-data-consent.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Firefox built-in consent for data collection and transmission
+description: Understand the Firefox built-in data consent mechanisms. Use Firefox's features to inform users about data collection in your extension.
 permalink: /documentation/develop/firefox-builtin-data-consent/
 topic: Develop
 tags: [data-collection, data-transmission, api, permissions, firefox, guide]

--- a/src/content/documentation/develop/firefox-workflow-overview.md
+++ b/src/content/documentation/develop/firefox-workflow-overview.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Firefox workflow overview
+description: Get an overview of the Firefox extension development workflow, from coding and testing to publishing and maintaining your extension.
 permalink: /documentation/develop/firefox-workflow-overview/
 topic: Develop
 tags:

--- a/src/content/documentation/develop/getting-started-with-web-ext.md
+++ b/src/content/documentation/develop/getting-started-with-web-ext.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Getting started with web-ext
+description: Start using the web-ext command-line tool. Automate and simplify your workflow for developing, running, and packaging Firefox extensions.
 permalink: /documentation/develop/getting-started-with-web-ext/
 topic: Develop
 tags: [guide, installing, packaging, testing, tools, web-ext, webextension]

--- a/src/content/documentation/develop/known-issues.md
+++ b/src/content/documentation/develop/known-issues.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Known issues
+description: Review known issues and limitations when developing Firefox extensions. Find workarounds and solutions for common development problems.
 permalink: /documentation/develop/known-issues/
 topic: Develop
 tags: [

--- a/src/content/documentation/develop/manifest-v3-migration-guide.md
+++ b/src/content/documentation/develop/manifest-v3-migration-guide.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar.liquid
 title: Manifest V3 migration guide
+description: Migrate your extension to Manifest V3. A comprehensive guide to understanding and implementing the necessary changes for your extension.
 permalink: /documentation/develop/manifest-v3-migration-guide/
 topic: Develop
 tags: [webextensions, api, firefox]

--- a/src/content/documentation/develop/onboard-upboard-offboard-users.md
+++ b/src/content/documentation/develop/onboard-upboard-offboard-users.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Onboard, upboard, offboard users
+description: Learn best practices for onboarding, upboarding, and offboarding users in your Firefox extension to always create a great impression.
 permalink: /documentation/develop/onboard-upboard-offboard-users/
 topic: Develop
 tags:

--- a/src/content/documentation/develop/porting-a-google-chrome-extension.md
+++ b/src/content/documentation/develop/porting-a-google-chrome-extension.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Porting a Google Chrome extension
+description: Efficiently port your Chrome extension to Firefox. Follow the step-by-step guide for converting your code and ensuring compatibility.
 permalink: /documentation/develop/porting-a-google-chrome-extension/
 topic: Develop
 tags: [webextensions]

--- a/src/content/documentation/develop/request-the-right-permissions.md
+++ b/src/content/documentation/develop/request-the-right-permissions.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Request the right permissions
+description: Learn how to request the right permissions for your Firefox extension. Follow security best practices and only request what your extension needs.
 permalink: /documentation/develop/request-the-right-permissions/
 topic: Develop
 tags: [add-ons, beginner, extensions, how-to, intermediate, permissions]

--- a/src/content/documentation/develop/temporary-installation-in-firefox.md
+++ b/src/content/documentation/develop/temporary-installation-in-firefox.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Temporary installation in Firefox
+description: Discover how to install your Firefox extension temporarily to enable effective testing and debugging before submitting to addons.mozilla.org (AMO).
 permalink: /documentation/develop/temporary-installation-in-firefox/
 topic: Develop
 tags: [webextensions]

--- a/src/content/documentation/develop/test-localizations.md
+++ b/src/content/documentation/develop/test-localizations.md
@@ -1,7 +1,7 @@
 ---
 layout: sidebar
 title: Testing localizations
-description: Learn how to test extension localizations using language packs in Firefox or Firefox Beta to ensure everything displays correctly in the Firefox and extension UI.
+description: Learn how to test extension localizations using language packs in Firefox or Firefox Beta to ensure a quality experience for users worldwide.
 permalink: /documentation/develop/test-localizations/
 topic: Develop
 tags: [add-ons, extensions, guide, permissions, testing, webextensions, localization]

--- a/src/content/documentation/develop/test-permission-requests.md
+++ b/src/content/documentation/develop/test-permission-requests.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Test permission requests
+description: Guide on how to test extension permission requests. Ensure your add-on prompts users correctly for access to browser features.
 permalink: /documentation/develop/test-permission-requests/
 topic: Develop
 tags: [add-ons, extensions, guide, permissions, testing, webextensions]

--- a/src/content/documentation/develop/testing-persistent-and-restart-features.md
+++ b/src/content/documentation/develop/testing-persistent-and-restart-features.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Testing persistent and restart features
+description: Learn to test persistent features in your Firefox extension, ensuring data integrity across browser restarts and session changes.
 permalink: /documentation/develop/testing-persistent-and-restart-features/
 topic: Develop
 tags:

--- a/src/content/documentation/develop/unique-firefox-capabilities.md
+++ b/src/content/documentation/develop/unique-firefox-capabilities.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Unique Firefox Capabilities
+description: Use unique Firefox WebExtension APIs and features not available elsewhere. Discover powerful tools to enhance your browser add-ons.
 permalink: /documentation/develop/unique-firefox-capabilities/
 topic: Develop
 tags: [getting-started, webextensions, api, firefox]

--- a/src/content/documentation/develop/user-experience-best-practices.md
+++ b/src/content/documentation/develop/user-experience-best-practices.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: User experience best practices
+description: Optimize the user experience of your Firefox add-on. Design accessible and intuitive interfaces with the official UX and design guidelines.
 permalink: /documentation/develop/user-experience-best-practices/
 topic: Develop
 tags: [add-ons, extensions, guide, ui, ux]

--- a/src/content/documentation/develop/ux-guidelines-for-mobile-extensions.md
+++ b/src/content/documentation/develop/ux-guidelines-for-mobile-extensions.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: User experience guidelines for mobile extensions
+description: Get user experience guidelines for mobile extensions on Firefox for Android. Design your add-on for a touch-friendly environment.
 permalink: /documentation/develop/user-experience-guidelines-for-mobile-extensions/
 topic: Develop
 tags: [add-ons, guide, mobile, webextensions, ux, user-experience]

--- a/src/content/documentation/develop/web-ext-command-reference-v7.md
+++ b/src/content/documentation/develop/web-ext-command-reference-v7.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar.liquid
 title: web-ext v7 command reference
+description: The full command reference for web-ext v7. Quickly look up commands for developing, testing, and packaging your Firefox extension.
 permalink: /documentation/develop/web-ext-command-reference-v7/
 topic: Develop
 tags: [commands, options, reference, tools, web-ext, webextensions]

--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar.liquid
 title: web-ext command reference
+description: The complete command reference for the web-ext tool. Quickly look up commands for developing, testing, and packaging your Firefox extension.
 permalink: /documentation/develop/web-ext-command-reference/
 topic: Develop
 tags: [commands, options, reference, tools, web-ext, webextensions]

--- a/src/content/documentation/enterprise.md
+++ b/src/content/documentation/enterprise.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Enhance your workflows with extensions for the enterprise
+description: Resources for deploying and managing Firefox extensions within your organization. Find documentation on enterprise policies and distribution methods.
 permalink: /documentation/enterprise/
 tags: [enterprise]
 contributors: [caitmuenster, mkaply]

--- a/src/content/documentation/enterprise/enterprise-development.md
+++ b/src/content/documentation/enterprise/enterprise-development.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Enterprise development
+description: Learn about developing Firefox extensions for enterprise use. Integrate your add-ons with corporate infrastructure and custom settings.
 permalink: /documentation/enterprise/enterprise-development/
 topic: Enterprise
 tags: [enterprise, policies]

--- a/src/content/documentation/enterprise/enterprise-distribution.md
+++ b/src/content/documentation/enterprise/enterprise-distribution.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Enterprise distribution
+description: Guide to distributing Firefox extensions to organizations. Learn about methods for enterprise-level deployment and management.
 permalink: /documentation/enterprise/enterprise-distribution/
 topic: Enterprise
 tags: [enterprise, policies, distribution, guide, installation]

--- a/src/content/documentation/enterprise/enterprise-policies-that-impact-extensions.md
+++ b/src/content/documentation/enterprise/enterprise-policies-that-impact-extensions.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Enterprise policies that impact extensions
+description: Understand the enterprise policies that impact Firefox extensions. Ensure your add-on functions correctly in corporate environments.
 permalink: /documentation/enterprise/enterprise-policies-that-impact-extensions/
 topic: Enterprise
 tags: [enterprise, policies]

--- a/src/content/documentation/manage.md
+++ b/src/content/documentation/manage.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Monitor and update your extension to keep users engaged
+description: Maintain and grow your Firefox add-on. Find resources for updating your extension, enterprise deployment support, and optimizing your listing.
 permalink: /documentation/manage/
 tags: [manage]
 contributors: [caitmuenster]

--- a/src/content/documentation/manage/best-practices-for-updating.md
+++ b/src/content/documentation/manage/best-practices-for-updating.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Best practices for updating your extension
+description: Follow best practices for updating your Firefox extension. Ensure a smooth transition for your users with every new version.
 permalink: /documentation/manage/best-practices-for-updating/
 topic: Manage
 tags: [update, manage, distribution]

--- a/src/content/documentation/manage/monitoring-extension-usage-statistics.md
+++ b/src/content/documentation/manage/monitoring-extension-usage-statistics.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Monitoring extension usage statistics
+description: Learn how to monitor extension usage statistics on addons.mozilla.org (AMO). Gain valuable insights into your add-on's performance and user base.
 permalink: /documentation/manage/monitoring-extension-usage-statistics/
 topic: Manage
 tags: [manage, distribution, amo, stats, usage, downloads]

--- a/src/content/documentation/manage/resources-for-publishers.md
+++ b/src/content/documentation/manage/resources-for-publishers.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Resources for publishers
+description: Essential resources and links for Firefox extension publishers. Stay up-to-date with news, community, and official documentation.
 permalink: /documentation/manage/resources-for-publishers/
 topic: Manage
 tags: [publish, manage, distribution]

--- a/src/content/documentation/manage/retiring-your-extension.md
+++ b/src/content/documentation/manage/retiring-your-extension.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Retiring your extension
+description: Learn the correct process for retiring your Firefox extension. Follow best practices to notify users and remove your add-on gracefully.
 permalink: /documentation/manage/retiring-your-extension/
 topic: Manage
 tags: [manage, end-of-life]

--- a/src/content/documentation/manage/updating-your-extension.md
+++ b/src/content/documentation/manage/updating-your-extension.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Updating your extension
+description: Step-by-step guide on updating your Firefox extension. Submit new versions and make changes to your add-on on addons.mozilla.org (AMO).
 permalink: /documentation/manage/updating-your-extension/
 topic: Manage
 tags: [update, manage, distribution]

--- a/src/content/documentation/publish.md
+++ b/src/content/documentation/publish.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Distribute and promote your extension to the right audience
+description: Everything you need to publish your Firefox extension on addons.mozilla.org (AMO). Understand add-on policies, signing, distribution methods, and effective promotion strategies.
 permalink: /documentation/publish/
 tags: []
 contributors: [caitmuenster,Nanush7]

--- a/src/content/documentation/publish/add-on-ownership.md
+++ b/src/content/documentation/publish/add-on-ownership.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Add-on ownership
+description: Understand the importance of add-on ownership and managing collaborators on  addons.mozilla.org (AMO). Protect your intellectual property and team access.
 permalink: /documentation/publish/add-on-ownership/
 topic: Publish
 tags: [development, ownership, code, dispute]

--- a/src/content/documentation/publish/add-on-policies-faq.md
+++ b/src/content/documentation/publish/add-on-policies-faq.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Add-on Policies FAQ
+description: Get answers to frequently asked questions about Firefox add-on policies. Clarify compliance for your extension submission.
 permalink: /documentation/publish/add-on-policies-faq/
 topic: Publish
 tags: [add-ons, review, policies, faq]

--- a/src/content/documentation/publish/add-on-policies.md
+++ b/src/content/documentation/publish/add-on-policies.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Add-on Policies
+description: The complete guide to Firefox add-on policies. Ensure your extension complies with all the requirements for security, functionality, and user data.
 permalink: /documentation/publish/add-on-policies/
 topic: Publish
 tags: [add-ons, review, policies]

--- a/src/content/documentation/publish/add-ons-blocking-process.md
+++ b/src/content/documentation/publish/add-ons-blocking-process.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Add-ons Blocking Process
+description: Understand the add-on blocking process for Firefox. Learn why an extension might be blocked and how to address related issues.
 permalink: /documentation/publish/add-ons-blocking-process/
 topic: Publish
 contributors: [caitmuenster, kewisch]

--- a/src/content/documentation/publish/create-an-appealing-listing.md
+++ b/src/content/documentation/publish/create-an-appealing-listing.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Create an appealing listing
+description: Maximize your visibility with an appealing add-on listing. Learn how to write a compelling description and choose effective screenshots for addons.mozilla.org (AMO).
 permalink: /documentation/develop/create-an-appealing-listing/
 topic: Publish
 tags: [add-ons, beginner, guide, publishing, webextension]

--- a/src/content/documentation/publish/developer-accounts.md
+++ b/src/content/documentation/publish/developer-accounts.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Developer accounts
+description: How to set up and manage your developer account on addons.mozilla.org (AMO). Start submitting and publishing your Firefox extensions.
 permalink: /documentation/publish/developer-accounts/
 topic: Publish
 tags: [development, extensions, publishing]

--- a/src/content/documentation/publish/distribute-for-desktop-apps.md
+++ b/src/content/documentation/publish/distribute-for-desktop-apps.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Add-ons for desktop apps
+description: Learn how to distribute extensions designed to work with desktop applications. Integrate your add-on with external software.
 permalink: /documentation/publish/distribute-for-desktop-apps/
 topic: Publish
 tags: [add-on, distribution, apps, desktop, guide, installation]

--- a/src/content/documentation/publish/distribute-manifest-versions.md
+++ b/src/content/documentation/publish/distribute-manifest-versions.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Distribute Manifest V2 and V3 extensions
+description: Guide on distributing extensions for different Manifest versions. Ensure your add-on reaches the widest possible user base.
 permalink: /documentation/publish/distribute-manifest-versions/
 topic: Publish
 tags: [add-ons, beginner, tutorial, webextensions]

--- a/src/content/documentation/publish/distribute-pre-release-versions.md
+++ b/src/content/documentation/publish/distribute-pre-release-versions.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Distribute pre-release versions
+description: Learn how to distribute pre-release or beta versions of your Firefox extension for testing with a select group of users.
 permalink: /documentation/publish/distribute-pre-release-versions/
 topic: Publish
 tags: [beta, alpha, testing, pre-release, publish, guide, how-to]

--- a/src/content/documentation/publish/firefox-add-on-distribution-agreement.md
+++ b/src/content/documentation/publish/firefox-add-on-distribution-agreement.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Firefox Add-on Distribution Agreement
+description: Read the Firefox Add-on Distribution Agreement. Essential legal information for every extension developer using addons.mozilla.org (AMO).
 permalink: /documentation/publish/firefox-add-on-distribution-agreement/
 topic: Publish
 tags: [add-on, agreement, firefox]
@@ -17,7 +18,6 @@ contributors:
     Adora,
     kmaglione,
   ]
-description: This page details the Firefox Add-on distribution agreement.
 last_updated_by: kewisch
 date: 2021-12-01
 ---

--- a/src/content/documentation/publish/install-self-distributed.md
+++ b/src/content/documentation/publish/install-self-distributed.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Installing self-distributed extensions
+description: Instructions on how users can install your self-distributed Firefox extension from a file on desktop or Android.
 permalink: /documentation/publish/install-self-distributed/
 topic: Publish
 tags: [add-on, distribution, testing, guide, installation]

--- a/src/content/documentation/publish/make-money-from-browser-extensions.md
+++ b/src/content/documentation/publish/make-money-from-browser-extensions.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Make money from browser extensions
+description: Explore options for how to make money from your browser extensions. Learn monetization strategies and policy compliance for Firefox add-ons.
 permalink: /documentation/publish/make-money-from-browser-extensions/
 topic: Publish
 tags: [add-on, distribution, guide, monetization]

--- a/src/content/documentation/publish/package-your-extension.md
+++ b/src/content/documentation/publish/package-your-extension.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Package your extension
+description: Step-by-step guide to packaging your Firefox extension into a distributable .zip file, ready for submission to addons.mozilla.org (AMO).
 permalink: /documentation/publish/package-your-extension/
 topic: Publish
 tags: [add-on, distribution, publication, reviews, signing, installation]

--- a/src/content/documentation/publish/promoting-your-extension.md
+++ b/src/content/documentation/publish/promoting-your-extension.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Promoting your extension or theme
+description: Learn strategies for promoting your Firefox extension and increasing downloads. Create an appealing listing and drive traffic to your add-on.
 permalink: /documentation/publish/promoting-your-extension/
 topic: Publish
 tags: [add-on, distribution, guide, promote]

--- a/src/content/documentation/publish/recommended-extensions.md
+++ b/src/content/documentation/publish/recommended-extensions.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Recommended extensions
+description: Learn how to get your Firefox extension nominated for the Recommended Extensions program. Meet high standards for quality and security.
 permalink: /documentation/publish/recommended-extensions/
 topic: Publish
 tags: [promote, recommended]

--- a/src/content/documentation/publish/self-distribution.md
+++ b/src/content/documentation/publish/self-distribution.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Distributing an add-on yourself
+description: Guide to self-distribution of your Firefox add-on, bypassing the public listing on addons.mozilla.org (AMO) while getting your extension signed.
 permalink: /documentation/publish/self-distribution/
 topic: Publish
 tags: [add-on, distribution, publication, reviews, signing, installation]

--- a/src/content/documentation/publish/signing-and-distribution-overview.md
+++ b/src/content/documentation/publish/signing-and-distribution-overview.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Signing and distribution overview
+description: Overview of the signing and distribution process for Firefox extensions. Get your add-on verified and ready for users.
 permalink: /documentation/publish/signing-and-distribution-overview/
 topic: Publish
 tags: [add-on, distribution, publication, reviews, signing, installation]

--- a/src/content/documentation/publish/source-code-submission.md
+++ b/src/content/documentation/publish/source-code-submission.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Source code submission
+description: Requirements for submitting your extension's source code. Essential if your add-on uses complex build processes or minified code.
 permalink: /documentation/publish/source-code-submission/
 topic: Publish
 tags: [add-ons, distribution, extensions, review-policy]

--- a/src/content/documentation/publish/submitting-an-add-on.md
+++ b/src/content/documentation/publish/submitting-an-add-on.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Submitting an add-on
+description: Step-by-step guide to submitting your Firefox extension to addons.mozilla.org (AMO) for review and publication. Get your add-on listed today.
 permalink: /documentation/publish/submitting-an-add-on/
 topic: Publish
 tags: [add-ons, beginner, tutorial, webextensions]

--- a/src/content/documentation/publish/third-party-library-usage.md
+++ b/src/content/documentation/publish/third-party-library-usage.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Third Party Library Usage
+description:  Guidelines for using third-party libraries and frameworks in your Firefox extension. Ensure compliance with all policies. 
 permalink: /documentation/publish/third-party-library-usage/
 topic: Publish
 tags: [add-ons, extensions, review-policy]

--- a/src/content/documentation/publish/version-compatibility.md
+++ b/src/content/documentation/publish/version-compatibility.md
@@ -1,7 +1,7 @@
 ---
 layout: sidebar
 title: Firefox version compatibility
-description: Learn how to customize your extension's Firefox version compatibility settings on addons.mozilla.org and when to use this feature.
+description: Learn how to customize your extension's Firefox version compatibility settings on addons.mozilla.org (AMO) and when to use this feature.
 permalink: /documentation/publish/version-compatibility/
 topic: Publish
 tags: [add-ons, intermediate, tutorial, webextensions, amo, distribution]

--- a/src/content/documentation/publish/version-rollback.md
+++ b/src/content/documentation/publish/version-rollback.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Version Rollback
+description: Learn how to perform a version rollback for your Firefox extension on addons.mozilla.org (AMO) if a critical issue is found in a new release.
 permalink: /documentation/publish/version-rollback/
 topic: Publish
 tags: [manage, distribution, review, add-ons, publishing]

--- a/src/content/documentation/publish/what-does-review-rejection-mean-to-users.md
+++ b/src/content/documentation/publish/what-does-review-rejection-mean-to-users.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: What does review rejection mean to users?
+description: Understand what a review rejection of your extension means for your users and how to communicate any changes effectively.
 permalink: /documentation/publish/what-does-review-rejection-mean-to-users/
 topic: Publish
 tags: [add-ons, extensions, guide, publication, review, webextensions]

--- a/src/content/documentation/themes.md
+++ b/src/content/documentation/themes.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Let users express their personality with themes
+description: Documentation for creating themes for Firefox. Customize the look and feel of the browser with guides on static and dynamic themes.
 permalink: /documentation/themes/
 tags: [themes]
 contributors: [caitmuenster]

--- a/src/content/documentation/themes/cross-browser-compatibility.md
+++ b/src/content/documentation/themes/cross-browser-compatibility.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Cross-browser compatibility
+description: Learn about cross-browser compatibility for themes. Build themes that work across Firefox and other browsers.
 permalink: /documentation/themes/cross-browser-compatibility/
 topic: Themes
 tags: [themes, compatibility, firefox]

--- a/src/content/documentation/themes/dynamic-themes.md
+++ b/src/content/documentation/themes/dynamic-themes.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Dynamic themes
+description: Guide to creating dynamic themes for Firefox that change based on user actions, time, or other conditions.
 permalink: /documentation/themes/dynamic-themes/
 topic: Themes
 tags: [themes, dynamic-themes, firefox]

--- a/src/content/documentation/themes/static-themes.md
+++ b/src/content/documentation/themes/static-themes.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Static themes
+description: Learn how to create static themes to customize Firefox's appearance, including colors, background images, and more.
 permalink: /documentation/themes/static-themes/
 topic: Themes
 tags: [themes, amo, firefox]

--- a/src/content/documentation/themes/using-the-amo-theme-generator.md
+++ b/src/content/documentation/themes/using-the-amo-theme-generator.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Using the AMO theme generator
+description: Use the addons.mozilla.org (AMO) Theme Generator tool to easily create and visualize your Firefox static themes before submission.
 permalink: /documentation/themes/using-the-amo-theme-generator/
 topic: Themes
 tags: [add-on, add-ons, amo, firefox, guide, tutorial, themes]

--- a/src/content/extension-basics.md
+++ b/src/content/extension-basics.md
@@ -1,6 +1,7 @@
 ---
 layout: sidebar
 title: Extension Basics
+description: Learn the basics of Firefox extension development. Explore the anatomy of a browser add-on, WebExtensions API concepts, and the manifest.json file.
 permalink: /extension-basics/
 tags: []
 contributors:

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -1076,7 +1076,7 @@
             "pages": [
               {
                 "title": "Create an appealing listing",
-                "url": "/documentation/develop/create-an-appealing-listing/",
+                "url": "/documentation/publish/create-an-appealing-listing/",
                 "subpageitems": [
                   {
                     "title": "Your add-on’s name",


### PR DESCRIPTION
This PR fixes #585 by adding a description to the front matter for each extension workshop page. The goal is to improve SEO by ensuring that search results have access to an appropriate meta description of each page.