### PR TITLE
Update firefox-builtin-data-consent.md , changed order for most AMO dev cases

### DIFF
--- a/src/content/documentation/develop/firefox-builtin-data-consent.md
+++ b/src/content/documentation/develop/firefox-builtin-data-consent.md
@@ -44,25 +44,7 @@ To use Firefox's built-in consent experience, you have to specify what data your
 
 ## Taxonomy
 
-Firefox uses categories to standardize data collection information for developers and users. In line with the [policies](/documentation/publish/add-on-policies/), there are two types of data: *Personal data* and *Technical and Interaction data*.
-
-### Personal data
-
-Personally identifiable information can be actively provided by the user or obtained through extension APIs. It includes, but isn’t limited to, names, email addresses, search terms, and browsing activity data, as well as access to and placement of cookies.
-
-| Data type<br>visible during install    | Data collection permission<br>used in the manifest | Definition and examples                                                                                                                                                                                           | Eligible for [implicit consent](/documentation/publish/add-on-policies/#data-collection-and-transmission-disclosure-and-control)? |
-|----------------------------------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Personally identifying information** | `personallyIdentifyingInfo`                          | Examples: contact information such as name and address, email, and phone number, as well as other identifying data such as ID numbers, voice or video recordings, age, demographic information, or biometric data. | no                                                                                                                                                |
-| **Health information**                 | `healthInfo`                                         | Examples: medical history, symptoms, diagnoses, treatments, procedures, or heart rate data.                                                                                                                     | no                                                                                                                                                |
-| **Financial and payment information**  | `financialAndPaymentInfo`                            | Examples: credit card numbers, transactions, credit ratings, financial statements, or payment history.                                                                                                          | no                                                                                                                                                |
-| **Authentication information**         | `authenticationInfo`                                 | Examples: passwords, usernames, personal identification numbers (PINs), security questions, and registration information for extensions that offer account-based services.                                      | no                                                                                                                                                |
-| **Personal communications**            | `personalCommunications`                             | Examples: emails, text or chat messages, social media posts, and data from phone calls and conference calls.                                                                                                    | no                                                                                                                                                |
-| **Location**                           | `locationInfo`                                       | Examples: region, GPS coordinates, or information about things near a user’s device.                                                                                                                            | yes                                                                                                                                               |
-| **Browsing activity**                  | `browsingActivity`                                   | Information about the websites users visit, such as specific URLs, domains, or categories of pages users view.                                                                                               | yes                                                                                                                                               |
-| **Website content**                    | `websiteContent`                                     | Covers anything visible on a website — such as text, images, videos, and links — and anything embedded, such as cookies, audio, page headers, and request and response information.                             | yes                                                                                                                                               |
-| **Website activity**                   | `websiteActivity`                                    | Examples: interactions and mouse and keyboard activity, such as scrolling, clicking, typing, and actions, such as saving and downloading.                                                                     | yes                                                                                                                                               |
-| **Search terms**                       | `searchTerms`                                        | Search terms entered into search engines or the browser.                                                                                                                                                        | yes                                                                                                                                               |
-| **Bookmarks**                          | `bookmarksInfo`                                      | Information about Firefox bookmarks, including specific websites, bookmark names, and folder names.                                                                                                             | yes                                                                                                                                               |
+Firefox uses categories to standardize data collection information for developers and users. In line with the [policies](/documentation/publish/add-on-policies/), there are two types of data: *Technical and Interaction data* and *Personal data*.
 
 ### Technical and interaction data
 
@@ -84,9 +66,71 @@ Technical data describes the environment the user is running, such as browser se
 
 {% capture content %}
 
+### Personal data
+
+Personally identifiable information can be actively provided by the user or obtained through extension APIs. It includes, but isn’t limited to, names, email addresses, search terms, and browsing activity data, as well as access to and placement of cookies.
+
+| Data type<br>visible during install    | Data collection permission<br>used in the manifest | Definition and examples                                                                                                                                                                                           | Eligible for [implicit consent](/documentation/publish/add-on-policies/#data-collection-and-transmission-disclosure-and-control)? |
+|----------------------------------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Personally identifying information** | `personallyIdentifyingInfo`                          | Examples: contact information such as name and address, email, and phone number, as well as other identifying data such as ID numbers, voice or video recordings, age, demographic information, or biometric data. | no                                                                                                                                                |
+| **Health information**                 | `healthInfo`                                         | Examples: medical history, symptoms, diagnoses, treatments, procedures, or heart rate data.                                                                                                                     | no                                                                                                                                                |
+| **Financial and payment information**  | `financialAndPaymentInfo`                            | Examples: credit card numbers, transactions, credit ratings, financial statements, or payment history.                                                                                                          | no                                                                                                                                                |
+| **Authentication information**         | `authenticationInfo`                                 | Examples: passwords, usernames, personal identification numbers (PINs), security questions, and registration information for extensions that offer account-based services.                                      | no                                                                                                                                                |
+| **Personal communications**            | `personalCommunications`                             | Examples: emails, text or chat messages, social media posts, and data from phone calls and conference calls.                                                                                                    | no                                                                                                                                                |
+| **Location**                           | `locationInfo`                                       | Examples: region, GPS coordinates, or information about things near a user’s device.                                                                                                                            | yes                                                                                                                                               |
+| **Browsing activity**                  | `browsingActivity`                                   | Information about the websites users visit, such as specific URLs, domains, or categories of pages users view.                                                                                               | yes                                                                                                                                               |
+| **Website content**                    | `websiteContent`                                     | Covers anything visible on a website — such as text, images, videos, and links — and anything embedded, such as cookies, audio, page headers, and request and response information.                             | yes                                                                                                                                               |
+| **Website activity**                   | `websiteActivity`                                    | Examples: interactions and mouse and keyboard activity, such as scrolling, clicking, typing, and actions, such as saving and downloading.                                                                     | yes                                                                                                                                               |
+| **Search terms**                       | `searchTerms`                                        | Search terms entered into search engines or the browser.                                                                                                                                                        | yes                                                                                                                                               |
+| **Bookmarks**                          | `bookmarksInfo`                                      | Information about Firefox bookmarks, including specific websites, bookmark names, and folder names.                                                                                                             | yes                                                                                                                                               |
+
 ## Specifying data types
 
 You specify the data types your extension transmits in the `browser_specific_settings.gecko.data_collection_permissions` key in the `manifest.json` file. As a reminder, the policies state that data transmission refers to any data collected, used, transferred, shared, or handled outside the add-on or the local browser.
+
+### Technical and interaction data
+
+The `technicalAndInteraction` data type behaves differently from all other data types. This data permission must be optional, but unlike other optional data collection options, the user can turn this permission on or off during the installation flow. This choice is available in the optional settings section of the extension installation prompt.
+
+### No data collection
+
+If your extension doesn’t collect or transmit any data, you indicate that by specifying the `none` required permission in the manifest, as follows:
+
+```json
+{
+  "manifest_version": 2,
+  "name": "extension without data collection",
+  "version": "1.0.0",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "@extension-without-data-collection",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
+    }
+  },
+  "permissions": [
+    "bookmarks",
+    "<all_urls>"
+  ]
+}
+```
+
+When a user attempts to install this extension, Firefox shows the usual installation prompt with the description of the required (API) permissions and a description to indicate that the extension doesn’t collect any data, like this:
+
+![The extension installation prompt shows the no data transmission ar defined in the manifest](/assets/img/documentation/develop/data-collection-permissions-prompt-install-no-transmission.webp)
+
+The "no data collected" type is also listed in the *Permissions and data* tab of the extension in `about:addons`, like this:
+
+![The  about:addons page shows the "no data collected" permission.](/assets/img/documentation/develop/data-collection-permissions-about-addons-no-transmission.webp)
+
+{% endcapture %}
+{% include modules/one-column.liquid,
+    id: "specifying-data-types"
+    content: content
+%}
+
+{% capture content %}
 
 ### Personal data
 
@@ -156,50 +200,6 @@ This adds the "required" data collection paragraph to the installation prompt. T
 #### Optional data
 
 Optional data collection permissions are specified using the optional list. These aren’t presented during installation (except for `technicalAndInteraction`), and they aren’t granted by default. The extension can request that the user opts in to this data collection after installation by calling [`permissions.request()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request) in a user-activated event handler, and the user can turn this optional data collection on or off in `about:addons` in the *Permissions and data* section of the extension settings.
-
-### Technical and interaction data
-
-The `technicalAndInteraction` data type behaves differently from all other data types. This data permission must be optional, but unlike other optional data collection options, the user can turn this permission on or off during the installation flow. This choice is available in the optional settings section of the extension installation prompt.
-
-### No data collection
-
-If your extension doesn’t collect or transmit any data, you indicate that by specifying the `none` required permission in the manifest, as follows:
-
-```json
-{
-  "manifest_version": 2,
-  "name": "extension without data collection",
-  "version": "1.0.0",
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "@extension-without-data-collection",
-      "data_collection_permissions": {
-        "required": ["none"]
-      }
-    }
-  },
-  "permissions": [
-    "bookmarks",
-    "<all_urls>"
-  ]
-}
-```
-
-When a user attempts to install this extension, Firefox shows the usual installation prompt with the description of the required (API) permissions and a description to indicate that the extension doesn’t collect any data, like this:
-
-![The extension installation prompt shows the no data transmission ar defined in the manifest](/assets/img/documentation/develop/data-collection-permissions-prompt-install-no-transmission.webp)
-
-The "no data collected" type is also listed in the *Permissions and data* tab of the extension in `about:addons`, like this:
-
-![The  about:addons page shows the "no data collected" permission.](/assets/img/documentation/develop/data-collection-permissions-about-addons-no-transmission.webp)
-
-{% endcapture %}
-{% include modules/one-column.liquid,
-    id: "specifying-data-types"
-    content: content
-%}
-
-{% capture content %}
 
 ## Accessing the data collection permissions programmatically
 


### PR DESCRIPTION
As most of us AMO devs likely don't even want to implement any type of data collection, added the most common mandatory option  ("required": ["none"]) for us AMO devs to the top for much easier finding