### PR TITLE
Update license field information in documentation

### DIFF
--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -665,7 +665,7 @@ A minimal JSON file looks like this:
 }
 ```
 
-See the [add-on server documentation](https://mozilla.github.io/addons-server/topics/api/licenses.html#license-list) for which values are accepted in the `"license"` field.
+The values accepted by the `"license"` field are listed in the [License Choices - non-Themes](https://mozilla.github.io/addons-server/topics/api/licenses.html#license-list) section of the addons-server API documentation.
 
 When publishing an extension update metadata isn't required. If metadata isn't provided, the license specified for the first version is reused. However, any of the properties of the [addons.mozilla.org add-on API Version Create request JSON object](https://mozilla.github.io/addons-server/topics/api/addons.html#version-create) can be provided. For example, if you want to specify `"approval_notes"`, the JSON file looks like this:
 

--- a/src/content/documentation/develop/web-ext-command-reference.md
+++ b/src/content/documentation/develop/web-ext-command-reference.md
@@ -665,7 +665,7 @@ A minimal JSON file looks like this:
 }
 ```
 
-The `"license"` field accepts one of these [SPDX identifiers](https://spdx.org/licenses/): `MPL-1.1`, `MPL-2.0`, `GPL-2.0-or-later`, `GPL-3.0-or-later`, `LGPL-2.1-or-later`, `LGPL-3.0-or-later`, `MIT`, `BSD-2-Clause`, `cc-all-rights-reserved`, `CC-BY-3.0`, `CC-BY-NC-3.0`, `CC-BY-NC-ND-3.0`, `CC-BY-NC-SA-3.0`, `CC-BY-ND-3.0`, `CC-BY-SA-3.0`, and `all-rights-reserved`.
+See the [add-on server documentation](https://mozilla.github.io/addons-server/topics/api/licenses.html#license-list) for which values are accepted in the `"license"` field.
 
 When publishing an extension update metadata isn't required. If metadata isn't provided, the license specified for the first version is reused. However, any of the properties of the [addons.mozilla.org add-on API Version Create request JSON object](https://mozilla.github.io/addons-server/topics/api/addons.html#version-create) can be provided. For example, if you want to specify `"approval_notes"`, the JSON file looks like this:
 


### PR DESCRIPTION
Replace the explicit list of accepted SPDX identifiers for the 'license' field with a link to the add-on server documentation.

Some of the values currently listed will return errors when submitted, e.g.:
```
WebExtError: Submission failed (2): Bad Request
{
  "version": {
    "license": [
      "License with slug=GPL-3.0-or-later does not exist."
    ]
  }
}
```