### PR TITLE
Updates about the webextension-polyfill

### DIFF
--- a/src/content/documentation/develop.md
+++ b/src/content/documentation/develop.md
@@ -37,7 +37,7 @@ All you need to create extensions for Firefox is a [text editor](https://develop
 
 ### Chromium-based browser extensions
 
-Starting with Chrome 148, Chrome supports the `browser` namespace, except in extensions that include a [DevTools page](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page). This limitation was removed in Chrome 152 (see [Chrome bug 500769389](https://crbug.com/500769389)), and the `browser` namespace became available to all Chrome extensions. This means that all major browsers use the `browser` namespace and return promises for asynchronous functions.
+Starting with Chrome 148, Chrome supports the `browser` namespace, except in extensions that include a [DevTools page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page). This limitation was removed in Chrome 152 (see [Chrome bug 500769389](https://crbug.com/500769389)), and the `browser` namespace became available to all Chrome extensions. This means that all major browsers use the `browser` namespace and return promises for asynchronous functions.
 
 Before Chrome 148, Chrome supports the `chrome` namespace only.
 

--- a/src/content/documentation/develop.md
+++ b/src/content/documentation/develop.md
@@ -37,9 +37,11 @@ All you need to create extensions for Firefox is a [text editor](https://develop
 
 ### Chromium-based browser extensions
 
-Get familiar with the [webextension-polyfill](https://github.com/mozilla/webextension-polyfill) library if you’re planning on developing for both Firefox and Chromium-based browsers.
+Starting with Chrome 148, Chrome supports the `browser` namespace, except in extensions that include a DevTools page. This limitation was removed in Chrome 152 (see [Chrome bug 500769389](https://crbug.com/500769389)), and the `browser` namespace became available to all Chrome extensions. This means that all major browsers use the `browser` namespace and return promises for asynchronous functions.
 
-This enables you to switch between the different Firefox and Chromium-based namespaces and asynchronous call handling methods for each type of browser.
+Before Chrome 148, Chrome uses the `chrome` namespace.
+
+If you want to use the `browser.*` namespace with promises and target Chrome 147 or earlier, you can use the [webextension-polyfill](https://github.com/mozilla/webextension-polyfill). This polyfill enables code that uses `browser` and promises to work unchanged in Chrome. This polyfill is a no-op in Chrome 148 and later.
 
 ### web-ext command line tool
 

--- a/src/content/documentation/develop.md
+++ b/src/content/documentation/develop.md
@@ -35,14 +35,6 @@ Support your development workflow with these straightforward tools and guides.
 
 All you need to create extensions for Firefox is a [text editor](https://developer.mozilla.org/docs/Learn/Common_questions/Available_text_editors) and [a version of Firefox](/documentation/develop/choosing-a-firefox-version-for-extension-development/) to support your testing. Mozilla and the Firefox extension developer community have also created a number of [extension development tools](/documentation/develop/browser-extension-development-tools/) that can simplify the coding and testing of your extension.
 
-### Chromium-based browser extensions
-
-Starting with Chrome 148, Chrome supports the `browser` namespace, except in extensions that include a [DevTools page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page). This limitation was removed in Chrome 152 (see [Chrome bug 500769389](https://crbug.com/500769389)), and the `browser` namespace became available to all Chrome extensions. This means that all major browsers use the `browser` namespace and return promises for asynchronous functions.
-
-Before Chrome 148, Chrome supports the `chrome` namespace only.
-
-If you want to use the `browser.*` namespace with promises and target Chrome 147 or earlier, you can use the [webextension-polyfill](https://github.com/mozilla/webextension-polyfill). This polyfill enables code that uses `browser` and promises to work unchanged in Chrome. This polyfill is a no-op in Chrome 148 and later (if `devtools_page` is used, no-op in Chrome 152 and later).
-
 ### web-ext command line tool
 
 The web-ext tool can help you by:

--- a/src/content/documentation/develop.md
+++ b/src/content/documentation/develop.md
@@ -4,9 +4,9 @@ title: Create extensions for Firefox and Firefox for Android
 description: Deep dive into developing Firefox extensions. Get guides on Manifest V3, cross-browser porting, security best practices, and debugging tools for your add-ons.
 permalink: /documentation/develop/
 tags: []
-contributors: [caitmuenster]
-last_updated_by: caitmuenster
-date: 2019-07-09 09:00:00
+contributors: [caitmuenster, rebloor]
+last_updated_by: rebloor
+date: 2026-08-05
 ---
 
 <!-- Overview Page Hero Banner -->

--- a/src/content/documentation/develop.md
+++ b/src/content/documentation/develop.md
@@ -37,11 +37,11 @@ All you need to create extensions for Firefox is a [text editor](https://develop
 
 ### Chromium-based browser extensions
 
-Starting with Chrome 148, Chrome supports the `browser` namespace, except in extensions that include a DevTools page. This limitation was removed in Chrome 152 (see [Chrome bug 500769389](https://crbug.com/500769389)), and the `browser` namespace became available to all Chrome extensions. This means that all major browsers use the `browser` namespace and return promises for asynchronous functions.
+Starting with Chrome 148, Chrome supports the `browser` namespace, except in extensions that include a [DevTools page](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page). This limitation was removed in Chrome 152 (see [Chrome bug 500769389](https://crbug.com/500769389)), and the `browser` namespace became available to all Chrome extensions. This means that all major browsers use the `browser` namespace and return promises for asynchronous functions.
 
-Before Chrome 148, Chrome uses the `chrome` namespace.
+Before Chrome 148, Chrome supports the `chrome` namespace only.
 
-If you want to use the `browser.*` namespace with promises and target Chrome 147 or earlier, you can use the [webextension-polyfill](https://github.com/mozilla/webextension-polyfill). This polyfill enables code that uses `browser` and promises to work unchanged in Chrome. This polyfill is a no-op in Chrome 148 and later.
+If you want to use the `browser.*` namespace with promises and target Chrome 147 or earlier, you can use the [webextension-polyfill](https://github.com/mozilla/webextension-polyfill). This polyfill enables code that uses `browser` and promises to work unchanged in Chrome. This polyfill is a no-op in Chrome 148 and later (if `devtools_page` is used, no-op in Chrome 152 and later).
 
 ### web-ext command line tool
 

--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -7,7 +7,7 @@ topic: Develop
 tags: [beginner, extensions, webextensions, compatibility, cross-browser]
 contributors: [rebloor]
 last_updated_by: rebloor
-date: 2019-05-27 6:35:30
+date: 2026-08-05
 ---
 
 <!-- Page Hero Banner -->
@@ -27,13 +27,14 @@ date: 2019-05-27 6:35:30
 
 {% capture content_with_toc %}
 
-While work continues to standardize the APIs used for browser extension development, there remain differences between Chromium-based browsers—such as Chrome, Opera, Microsoft Edge—and Firefox. These differences, summarized on this page, include:
+All browsers have the same baseline support for namespace (`browser.*`) and promises:
 
-- **Namespace**:
-- `browser.*`, the standard for the extensions API. Originally supported only by Firefox and Safari, [Chromium-based browsers added support](https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace) in 2026. The [webextension-polyfill](https://github.com/mozilla/webextension-polyfill) provides the `browser` namespace for older Chromium browsers that don't support it natively.
-  - `chrome.*` supported by all browsers.
-- **Asynchronous APIs**: Promises are used by Firefox and Safari. Chrome, Opera, and Edge began introducing promises with Manifest V3, and they are available for all relevant APIs in Chrome 152.
-- **API support**: Support for JavaScript APIs differs among browsers.
+- Firefox and Safari supported the `browser.*` namespace and promises from inception.
+- Chromium-based browsers (such as Chrome, Opera, and Microsoft Edge) introduced promises with Manifest V3, except for DevTools APIs. Support for the `browser.*` namespace was added [in 2026](https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace), along with promise support in all asynchronous methods.
+
+While work continues to standardize the browser extension APIs, differences remain among the Firefox, Safari, and Chromium-based browsers. These differences, summarized on this page, include:
+
+- **API support**: JavaScript API support varies among browsers.
 - **Manifest key support**: Support for `manifest.json` keys differs among browsers.
 - Variations due to differences in browser behavior.
 
@@ -51,14 +52,17 @@ For information on building an extension that works on multiple browsers and acc
 
 {% capture content %}
 
-## Namespace
+## Namespace and asynchronous methods
 
-You reference all extensions API functions using a namespace, for example, `browser.alarms.create({delayInMinutes});` would create an alarm in Firefox that goes off after the time specified in `delayInMinutes`.
+You reference all extensions APIs using a namespace. For example, `browser.alarms.create({delayInMinutes});` creates an alarm that goes off after the time specified in `delayInMinutes`.
 
-There are two API namespaces in use:
+From mid-2026, all major browsers support the `browser` namespace and promises for asynchronous methods. Previously, Chromium-based browsers (such as Chrome, Opera, and Microsoft Edge) used only the `chrome` namespace with callbacks.
 
-- `browser`(the proposed standard) is used in Firefox. For example: `browser.browserAction.setIcon({path: "path/to/icon.png"});`
-- `chrome` is used in Chromium-based browsers. For example: `chrome.browserAction.setIcon({path: "path/to/icon.png"});`
+::: note
+As a porting aid, Firefox supports `chrome` using callbacks, alongside `browser` using promises. This means that many older Chrome extensions work in Firefox without changes, unless they use Chrome-specific APIs that don’t exist in Firefox.
+:::
+
+To target older Chromium-based browsers with extensions written using the `browser` namespace and promises, use the [webextension-polyfill](https://github.com/mozilla/webextension-polyfill).
 
 {% endcapture %}
 {% include modules/one-column.liquid,
@@ -72,15 +76,13 @@ There are two API namespaces in use:
 
 {% capture content %}
 
-## Asynchronous
+## Promises
 
-JavaScript provides several ways in which to handle asynchronous events. The proposed extensions API standard is to use the promise object. The promise approach provides significant advantages when dealing with chained asynchronous event calls.
+JavaScript provides several ways to handle asynchronous events. The extensions API standard is to use the promise object. The promise approach offers significant advantages when handling chained asynchronous event calls.
 
-Firefox uses the promise object for all asynchronous WebExtensions APIs. Chromium-based browsers use callbacks.
+Firefox has always used the promise object. Chromium-based browsers historically supported callbacks through the `chrome` namespace, which is why many extensions and samples use callbacks. Chromium-based browsers now support promises through the `browser` namespace, so you no longer need to design around this for current browser versions.
 
-As a porting aid, the Firefox WebExtension APIs supports `chrome` using callbacks and `browser` using promise. This means that many Chrome extensions will work in Firefox without changes, unless they are using Chrome specific APIs that don’t exist in Firefox.
-
-In Chrome, asynchronous APIs use callbacks to return values, and [`runtime.lastError`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/lastError) to communicate errors:
+So, extensions and samples written against the older, callback-only Chrome APIs use the `chrome` namespace, with callbacks to return values, and [`runtime.lastError`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/lastError) to communicate errors:
 
 ```js
 function logCookie(c) {
@@ -94,7 +96,7 @@ function logCookie(c) {
 chrome.cookies.set({ url: "https://developer.mozilla.org/" }, logCookie);
 ```
 
-The equivalent WebExtensions API code using [promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise):
+The equivalent code using the `browser` namespace and [promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise):
 
 ```js
 function logCookie(c) {
@@ -123,7 +125,7 @@ If you are unfamiliar with how JavaScript can handle asynchronous events or prom
 
 {% capture content %}
 
-## API Coverage
+## API coverage
 
 The differences in the extensions API function implementations among the browsers fall into two broad categories:
 

--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -30,7 +30,7 @@ date: 2019-05-27 6:35:30
 While work continues to standardize the APIs used for browser extension development, there remain differences between Chromium-based browsers—such as Chrome, Opera, and the Chromium-based Microsoft Edge—and Firefox. These differences, summarized on this page, include:
 
 - **Namespace**:
-- `browser.*`, the standard for the extensions API used by Firefox, Safari, Chrome (from 148), Opera (from 121), and Edge (from 136).
+- `browser.*`, the standard for the extensions API used by Firefox, Safari, Chrome (from 148), Opera (from 121), and Edge (from 136). Note: `browser.*` [isn't supported for DevTools extensions](https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace) until Chrome 152, Opera 125, and Edge 140. For support, see the [webextension-polyfill](https://github.com/mozilla/webextension-polyfill).
   - `chrome.*` supported by all browsers.
 - **Asynchronous APIs**: Promises are used by Firefox and Safari. Chrome, Opera, and Edge began introducing promises with Manifest V3, and they are available for all relevant APIs in Chrome 152.
 - **API support**: Support for JavaScript APIs differs among browsers.

--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -27,10 +27,10 @@ date: 2019-05-27 6:35:30
 
 {% capture content_with_toc %}
 
-While work continues to standardize the APIs used for browser extension development, there remain differences between Chromium-based browsers—such as Chrome, Opera, and the Chromium-based Microsoft Edge—and Firefox. These differences, summarized on this page, include:
+While work continues to standardize the APIs used for browser extension development, there remain differences between Chromium-based browsers—such as Chrome, Opera, Microsoft Edge—and Firefox. These differences, summarized on this page, include:
 
 - **Namespace**:
-- `browser.*`, the standard for the extensions API used by Firefox, Safari, Chrome (from 148), Opera (from 121), and Edge (from 136). Note: `browser.*` [isn't supported for DevTools extensions](https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace) until Chrome 152, Opera 125, and Edge 140. For support, see the [webextension-polyfill](https://github.com/mozilla/webextension-polyfill).
+- `browser.*`, the standard for the extensions API. Originally supported only by Firefox and Safari, [Chromium-based browsers added support](https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace) in 2026. The [webextension-polyfill](https://github.com/mozilla/webextension-polyfill) provides the `browser` namespace for older Chromium browsers that don't support it natively.
   - `chrome.*` supported by all browsers.
 - **Asynchronous APIs**: Promises are used by Firefox and Safari. Chrome, Opera, and Edge began introducing promises with Manifest V3, and they are available for all relevant APIs in Chrome 152.
 - **API support**: Support for JavaScript APIs differs among browsers.

--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -30,7 +30,7 @@ date: 2026-08-05
 All browsers have the same baseline support for namespace (`browser.*`) and promises:
 
 - Firefox and Safari supported the `browser.*` namespace and promises from inception.
-- Chromium-based browsers (such as Chrome, Opera, and Microsoft Edge) introduced promises with Manifest V3, except for DevTools APIs. Support for the `browser.*` namespace was added [in 2026](https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace), along with promise support in all asynchronous methods.
+- Chromium-based browsers (such as Chrome, Opera, and Microsoft Edge) introduced promises with Manifest V3 in their `chrome.*` namespace. Support for the `browser.*` namespace was added [in 2026](https://developer.chrome.com/docs/extensions/develop/concepts/browser-namespace), along with promise support in all asynchronous methods.
 
 While work continues to standardize the browser extension APIs, differences remain among the Firefox, Safari, and Chromium-based browsers. These differences, summarized on this page, include:
 

--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -56,7 +56,7 @@ For information on building an extension that works on multiple browsers and acc
 
 You reference all extensions APIs using a namespace. For example, `browser.alarms.create({delayInMinutes});` creates an alarm that goes off after the time specified in `delayInMinutes`.
 
-From mid-2026, all major browsers support the `browser` namespace and promises for asynchronous methods. Previously, Chromium-based browsers (such as Chrome, Opera, and Microsoft Edge) used only the `chrome` namespace with callbacks.
+All major browsers now support the `browser` namespace and promises for asynchronous methods. Chromium-based browsers (such as Chrome, Opera, and Microsoft Edge) originally used the `chrome` namespace with callbacks. They progressively migrated to the `browser` namespace and promises, completing the full implementation in mid-2026.
 
 ::: note
 As a porting aid, Firefox supports `chrome` using callbacks, alongside `browser` using promises. This means that many older Chrome extensions work in Firefox without changes, unless they use Chrome-specific APIs that don’t exist in Firefox.

--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -31,7 +31,7 @@ While work continues to standardize the APIs used for browser extension developm
 
 - **Namespace**:
 - `browser.*`, the standard for the extensions API used by Firefox, Safari, Chrome (from 148), Opera (from 121), and Edge (from 136).
-  - `chrome.*` used by Chrome, Opera, and Edge.
+  - `chrome.*` supported by all browsers.
 - **Asynchronous APIs**: Promises are used by Firefox and Safari. Chrome, Opera, and Edge began introducing promises with Manifest V3, and they are available for all relevant APIs in Chrome 152.
 - **API support**: Support for JavaScript APIs differs among browsers.
 - **Manifest key support**: Support for `manifest.json` keys differs among browsers.

--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -56,7 +56,7 @@ For information on building an extension that works on multiple browsers and acc
 
 You reference all extensions APIs using a namespace. For example, `browser.alarms.create({delayInMinutes});` creates an alarm that goes off after the time specified in `delayInMinutes`.
 
-All major browsers now support the `browser` namespace and promises for asynchronous methods. Chromium-based browsers (such as Chrome, Opera, and Microsoft Edge) originally used the `chrome` namespace with callbacks. They progressively migrated to the `browser` namespace and promises, completing the full implementation in mid-2026.
+All major browsers now support the `browser` namespace and promises for asynchronous methods. Chromium-based browsers (such as Chrome, Opera, and Microsoft Edge) originally used the `chrome` namespace with callbacks. They progressively included support for promises in the `chrome` namespace, completing the full implementation along with support for the `browser` namespace in mid-2026.
 
 ::: note
 As a porting aid, Firefox supports `chrome` using callbacks, alongside `browser` using promises. This means that many older Chrome extensions work in Firefox without changes, unless they use Chrome-specific APIs that don’t exist in Firefox.

--- a/src/content/documentation/develop/browser-compatibility.md
+++ b/src/content/documentation/develop/browser-compatibility.md
@@ -29,13 +29,15 @@ date: 2019-05-27 6:35:30
 
 While work continues to standardize the APIs used for browser extension development, there remain differences between Chromium-based browsers—such as Chrome, Opera, and the Chromium-based Microsoft Edge—and Firefox. These differences, summarized on this page, include:
 
-- **Namespace**: In Chromium-based browsers, JavaScript APIs are accessed under the `chrome` namespace. In Firefox, they are accessed under the `browser` namespace.
-- **Asynchronous APIs**: In Chromium-based browsers, asynchronous APIs are implemented using callbacks. In Firefox, asynchronous APIs are implemented using promise.
+- **Namespace**:
+- `browser.*`, the standard for the extensions API used by Firefox, Safari, Chrome (from 148), Opera (from 121), and Edge (from 136).
+  - `chrome.*` used by Chrome, Opera, and Edge.
+- **Asynchronous APIs**: Promises are used by Firefox and Safari. Chrome, Opera, and Edge began introducing promises with Manifest V3, and they are available for all relevant APIs in Chrome 152.
 - **API support**: Support for JavaScript APIs differs among browsers.
 - **Manifest key support**: Support for `manifest.json` keys differs among browsers.
 - Variations due to differences in browser behavior.
 
-Firefox is the most compliant with the proposed standard, and is, therefore, your best place to start when developing browser extensions. A simple way of addressing many of these differences is by using the [web extension polyfill library](https://github.com/mozilla/webextension-polyfill). For an introduction to using this tool, see [Building a cross-browser extension](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension). Note, however, that the polyfill does not support Firefox exclusive APIs that are not available in Chrome.
+For information on building an extension that works on multiple browsers and accounts for these differences, see [Building a cross-browser extension](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension).
 
 {% endcapture %}
 {% include modules/column-w-toc.liquid,

--- a/src/content/documentation/develop/browser-extension-development-tools.md
+++ b/src/content/documentation/develop/browser-extension-development-tools.md
@@ -211,9 +211,13 @@ To get started, add the plug-in to your `webpack.config.js`.
 
 ### WebExtension browser API Polyfill
 
-When creating extensions you want to work in Firefox and Chrome, this library enables you to use the Firefox Promise-based APIs and have them run on Google Chrome with few, if any, changes.
+When creating extensions you want to work in Firefox and Chrome, this library enables you to use the Firefox promise-based APIs and have them run on Google Chrome with few, if any, changes.
 
-To get started, install using npm and load the library into the contexts where browser APIs are accessed.
+However, starting with Chrome 148, Chrome supports the `browser` namespace, except in extensions that include a DevTools page. That limitation was removed in Chrome 152 (see [Chrome bug 500769389](https://crbug.com/500769389)), and the `browser` namespace became available to all Chrome extensions.
+
+This means that all major browsers use the `browser` namespace and return promises for asynchronous functions. This polyfill is a no-op in Chrome 148 and later.
+
+If you want to enable your extension for Chrome 147 or earlier, get started by installing with npm and loading the library in the contexts where browser APIs are accessed.
 
 [Get started](https://github.com/mozilla/webextension-polyfill/#installation)
 

--- a/src/content/documentation/develop/browser-extension-development-tools.md
+++ b/src/content/documentation/develop/browser-extension-development-tools.md
@@ -18,7 +18,7 @@ tags:
   ]
 contributors: [rebloor, hellosct1, ani-sha, ankushduacodes]
 last_updated_by: rebloor
-date: 2023-06-02
+date: 2026-08-05
 ---
 
 <!-- Page Hero Banner -->


### PR DESCRIPTION
### Description

These changes are designed to emphasize that the webextension-polyfill is now only needed when an extension targets Chrome 147 or earlier.

### Related issues and pull requests

Related changes to MDN content in https://github.com/mdn/content/pull/44951.